### PR TITLE
Sync Architecture Audit and Fix

### DIFF
--- a/AppContent.tsx
+++ b/AppContent.tsx
@@ -183,7 +183,6 @@ function AppContent() {
             jwtExpiresAt: getJWTExpiry(),
             lastError: null,
           })
-          refreshFlowProgress()
           try {
             const savedLanguage = localStorage.getItem('menhausen-language')
             if (savedLanguage && (savedLanguage === 'en' || savedLanguage === 'ru')) {

--- a/AppContent.tsx
+++ b/AppContent.tsx
@@ -29,7 +29,7 @@ import {
   goBack,
 } from './src/stores/navigation.store'
 
-import { refreshFlowProgress, loadFlowProgressFromLocalStorage } from './src/stores/app-flow.store'
+import { loadFlowProgressFromLocalStorage } from './src/stores/app-flow.store'
 import { getSyncService } from '@/utils/supabaseSync/supabaseSyncService'
 import { $lastSyncTime, forceSync } from './src/stores/sync.store'
 import { setAuthState } from './src/stores/auth.store'
@@ -38,6 +38,7 @@ import { shouldPullSyncOnForeground } from './src/utils/visibilitySync'
 import { $screenParams } from './src/stores/screen-params.store'
 import { checkAndShowAchievements } from './src/stores/actions/achievement-display.actions'
 import { useRewardDisplayOrchestrator } from './hooks/useRewardDisplayOrchestrator'
+import { SyncIncrementalErrorBanner } from './components/SyncIncrementalErrorBanner'
 
 function AppContent() {
   const { language: currentLanguageFromContext, setLanguage: updateLanguage } = useLanguage()
@@ -358,6 +359,7 @@ function AppContent() {
 
   return (
     <ContentLoadingGate>
+      <SyncIncrementalErrorBanner />
       <div className="w-full h-screen max-h-screen relative overflow-hidden overflow-x-hidden bg-[#111111] flex flex-col">
         <div className="flex-1 relative w-full h-full overflow-hidden overflow-x-hidden">
           <BackButton isHomePage={isHomePage} onBack={goBack} />

--- a/components/SyncIncrementalErrorBanner.tsx
+++ b/components/SyncIncrementalErrorBanner.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useRef } from 'react'
+import { useStore } from '@nanostores/react'
+
+import { capture, AnalyticsEvent } from '@/src/effects/analytics.effects'
+import { errorsMessages } from '@/src/i18n/messages/errors'
+import { $incrementalSyncError, setIncrementalSyncError } from '@/src/stores/incremental-sync.store'
+
+/**
+ * Non-blocking banner when batched/incremental sync fails (distinct from initial mount sync).
+ */
+export function SyncIncrementalErrorBanner() {
+  const rawMessage = useStore($incrementalSyncError)
+  const errors = useStore(errorsMessages)
+  const lastCaptured = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (!rawMessage) {
+      lastCaptured.current = null
+      return
+    }
+    if (lastCaptured.current === rawMessage) return
+    lastCaptured.current = rawMessage
+    capture(AnalyticsEvent.INCREMENTAL_SYNC_ERROR_SHOWN, {
+      message_length: rawMessage.length,
+    })
+  }, [rawMessage])
+
+  if (!rawMessage) return null
+
+  return (
+    <div
+      className="fixed left-0 right-0 top-0 z-[100] px-3 pb-2 pt-[max(0.5rem,env(safe-area-inset-top,0px))] flex flex-col gap-1 bg-[#2a1818] border-b border-red-900/50 shadow-md"
+      role="alert"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-medium text-red-100">{errors.syncIncrementalErrorTitle}</p>
+          <p className="text-xs text-red-200/90 mt-0.5">{errors.syncIncrementalErrorHint}</p>
+          {import.meta.env.DEV && (
+            <p className="text-[10px] font-mono text-red-300/80 mt-1 break-all">{rawMessage}</p>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={() => setIncrementalSyncError(null)}
+          className="shrink-0 text-xs text-red-100/90 underline underline-offset-2 hover:text-white"
+        >
+          {errors.syncIncrementalErrorDismiss}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/docs/sync-architecture-audit-closure.md
+++ b/docs/sync-architecture-audit-closure.md
@@ -1,0 +1,36 @@
+# Sync architecture audit — closure
+
+This document records completion of the sync architecture audit and how open review notes were resolved. The original audit plan lives in the Cursor plans workspace (`sync_architecture_audit_0bc3850c.plan.md`).
+
+## Completed (P0–P2, P3-13/14)
+
+- **P0:** Fetch cache cleared before `initialSync` / `forceSync`; mutex serializes concurrent syncs; missing store subscriptions added; synchronous hydration after merge.
+- **P1:** Failed background uploads queued; dirty-only push after merge; exponential backoff on offline queue; keepalive size check with offline fallback.
+- **P2:** Cross-tab `BroadcastChannel` + store refresh; incremental sync error atom; premium activation delay removed.
+- **P3-13:** Analytics `synced_types` populated with actual types.
+- **P3-14:** Redundant refreshes addressed via sync hydration.
+
+## Explicitly deferred
+
+- **§4 follow-ups** from the audit (Supabase Realtime, React Query, per-type `sync_version`, payload compression, service worker): unchanged — backend or large refactors.
+- **Snapshot signature performance:** full `JSON.stringify` per type; revisit with profiling if needed.
+- **P3-12 verbose logs:** `syncLog.debug` is development-only via [`utils/supabaseSync/syncLogger.ts`](../utils/supabaseSync/syncLogger.ts); production hot paths are not spammed.
+
+## Superseded plan items
+
+- **`awaitCurrentSync` / `$pendingSyncCount` on `sync.store`:** concurrency is handled inside `SupabaseSyncService` (`syncMutex`); queue visibility uses `$pendingSyncQueueCount`.
+
+## Wrap-up shipped in this repo
+
+- Pure **dirty signature** helpers + unit tests: [`utils/supabaseSync/dirtySignatures.ts`](../utils/supabaseSync/dirtySignatures.ts), tests under `tests/unit/`.
+- **Incremental sync error** surfaced in the UI with i18n-safe copy; optional PostHog event when the banner is shown.
+- **Cross-tab sync:** richer context on refresh failure logs in [`src/sync/crossTabSync.ts`](../src/sync/crossTabSync.ts).
+
+## Manual QA matrix
+
+| Scenario | Check |
+|----------|--------|
+| Foreground after long background | Fresh pull after cache clear; no dropped `forceSync` |
+| Two tabs | Other tab refreshes after sync completes |
+| Offline → online | Offline queue retries with backoff |
+| Large payload on page hide | Oversized keepalive falls back to offline queue |

--- a/main.tsx
+++ b/main.tsx
@@ -11,6 +11,7 @@ import { ErrorFallback } from './components/ErrorFallback'
 import { captureException } from './src/effects/analytics.effects'
 import { isTelegramWebAppAvailable } from './src/effects/telegram.effects'
 import { initStoreSyncSubscriptions } from './src/sync/storeSyncSubscriptions'
+import { initCrossTabSyncListener } from './src/sync/crossTabSync'
 
 // Ensure DOM is ready
 const root = document.getElementById('root')
@@ -75,6 +76,7 @@ if (isAnalyticsEnabled()) {
 }
 
 initStoreSyncSubscriptions()
+initCrossTabSyncListener()
 
 // Initialize React app
 const app = (

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "menhausen-telegram-mini-app",
-  "version": "1.2.87",
+  "version": "1.2.88",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "menhausen-telegram-mini-app",
-      "version": "1.2.87",
+      "version": "1.2.88",
       "dependencies": {
         "@floating-ui/react": "^0.26.0",
         "@nanostores/i18n": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "menhausen-telegram-mini-app",
   "private": true,
-  "version": "1.2.87",
+  "version": "1.2.88",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/services/userStatsService.ts
+++ b/services/userStatsService.ts
@@ -2,6 +2,8 @@
  * Сервис для управления статистикой пользователя
  */
 
+import { bumpUserStatsSyncVersion } from '@/src/stores/sync-triggers.store';
+
 import { UserStats } from '../types/achievements';
 import { NON_ACHIEVEMENT_ARTICLE_IDS } from '../utils/articlesList';
 
@@ -59,6 +61,7 @@ export function saveUserStats(stats: UserStats): void {
       lastUpdated: new Date().toISOString()
     };
     localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+    bumpUserStatsSyncVersion();
   } catch (error) {
     console.error('Error saving user stats:', error);
   }

--- a/src/i18n/messages/errors.ts
+++ b/src/i18n/messages/errors.ts
@@ -8,5 +8,8 @@ export const errorsMessages = i18n('errors', {
   contentUnavailable: "Content is unavailable",
   themeNotFound: "Theme not found",
   themeListLoadingError: "Failed to load themes",
-  loadingDataError: "Failed to load data"
+  loadingDataError: "Failed to load data",
+  syncIncrementalErrorTitle: "Couldn't sync your latest changes",
+  syncIncrementalErrorHint: "We'll retry automatically. If this keeps happening, try reloading the app.",
+  syncIncrementalErrorDismiss: "Dismiss"
 } as any)

--- a/src/stores/incremental-sync.store.ts
+++ b/src/stores/incremental-sync.store.ts
@@ -1,0 +1,15 @@
+import { atom } from 'nanostores'
+
+/** Last error from batched / incremental sync (not initial mount sync). */
+export const $incrementalSyncError = atom<string | null>(null)
+
+export function setIncrementalSyncError(message: string | null): void {
+  $incrementalSyncError.set(message)
+}
+
+/** Mirrors `supabase_sync_queue` length for UI visibility. */
+export const $pendingSyncQueueCount = atom(0)
+
+export function setPendingSyncQueueCount(count: number): void {
+  $pendingSyncQueueCount.set(count)
+}

--- a/src/stores/premium.store.ts
+++ b/src/stores/premium.store.ts
@@ -153,32 +153,29 @@ function handlePremiumActivatedEvent(event: Event) {
     purchasedAt
   })
 
-  // Attempt to refresh the verified signature a bit later, similar to previous App behavior.
+  // Refresh verified signature immediately (no artificial delay).
   if (typeof window !== 'undefined') {
-    setTimeout(() => {
-      void (async () => {
-        try {
-          // If signature is already in storage, prefer it; otherwise fetch from Supabase.
-          const existingSig = loadPremiumSignatureFromStorage()
-          if (existingSig) {
-            const verified = await getVerifiedPremiumStatus()
-            if (verified) {
-              setPremium(verified.premium, {
-                source: 'verifiedLocalStorage',
-                plan: verified.plan,
-                expiresAt: verified.expiresAt,
-                purchasedAt: verified.purchasedAt
-              })
-            }
-            return
+    void (async () => {
+      try {
+        const existingSig = loadPremiumSignatureFromStorage()
+        if (existingSig) {
+          const verified = await getVerifiedPremiumStatus()
+          if (verified) {
+            setPremium(verified.premium, {
+              source: 'verifiedLocalStorage',
+              plan: verified.plan,
+              expiresAt: verified.expiresAt,
+              purchasedAt: verified.purchasedAt
+            })
           }
-
-          await loadPremiumFromSupabase()
-        } catch {
-          // ignore and keep optimistic state
+          return
         }
-      })()
-    }, 1000)
+
+        await loadPremiumFromSupabase()
+      } catch {
+        // ignore and keep optimistic state
+      }
+    })()
   }
 }
 

--- a/src/stores/sync-triggers.store.ts
+++ b/src/stores/sync-triggers.store.ts
@@ -1,0 +1,20 @@
+/**
+ * Bumped when domain data changes that must enqueue incremental sync but are not
+ * covered by other nanostores (user stats, psych test persistence, referral keys).
+ */
+import { atom } from 'nanostores'
+
+export const $userStatsVersion = atom(0)
+export function bumpUserStatsSyncVersion(): void {
+  $userStatsVersion.set($userStatsVersion.get() + 1)
+}
+
+export const $psychologicalTestStorageVersion = atom(0)
+export function bumpPsychologicalTestSyncVersion(): void {
+  $psychologicalTestStorageVersion.set($psychologicalTestStorageVersion.get() + 1)
+}
+
+export const $referralDataVersion = atom(0)
+export function bumpReferralDataSyncVersion(): void {
+  $referralDataVersion.set($referralDataVersion.get() + 1)
+}

--- a/src/stores/sync.store.ts
+++ b/src/stores/sync.store.ts
@@ -8,6 +8,11 @@ export const $syncStatus = atom<SyncStatus>('idle')
 export const $lastSyncTime = atom<Date | null>(null)
 export const $syncError = atom<string | null>(null)
 
+export {
+  $incrementalSyncError,
+  $pendingSyncQueueCount,
+} from '@/src/stores/incremental-sync.store'
+
 export async function initSync(): Promise<SyncResult> {
   $syncError.set(null)
   $syncStatus.set('syncing')

--- a/src/sync/crossTabSync.ts
+++ b/src/sync/crossTabSync.ts
@@ -23,7 +23,8 @@ export function initCrossTabSyncListener(): void {
       try {
         refreshAllStoresFromStorage()
       } catch (e) {
-        console.warn('[crossTabSync] refresh failed:', e)
+        const ts = ev.data && typeof ev.data === 'object' && 'ts' in ev.data ? (ev.data as { ts?: number }).ts : undefined
+        console.warn('[crossTabSync] refresh failed:', e, ts != null ? { broadcastTs: ts } : {})
       }
     }
   }

--- a/src/sync/crossTabSync.ts
+++ b/src/sync/crossTabSync.ts
@@ -1,0 +1,38 @@
+/**
+ * When one tab completes a remote sync, notify other tabs to re-read localStorage into nanostores.
+ */
+import { refreshAllStoresFromStorage } from '@/src/sync/storeHydration'
+
+const CHANNEL_NAME = 'menhausen-sync-v1'
+
+let channel: BroadcastChannel | null = null
+
+function getChannel(): BroadcastChannel | null {
+  if (typeof BroadcastChannel === 'undefined') return null
+  if (!channel) {
+    channel = new BroadcastChannel(CHANNEL_NAME)
+  }
+  return channel
+}
+
+export function initCrossTabSyncListener(): void {
+  const ch = getChannel()
+  if (!ch) return
+  ch.onmessage = (ev: MessageEvent) => {
+    if (ev.data?.type === 'sync-complete') {
+      try {
+        refreshAllStoresFromStorage()
+      } catch (e) {
+        console.warn('[crossTabSync] refresh failed:', e)
+      }
+    }
+  }
+}
+
+export function notifyCrossTabSyncComplete(): void {
+  try {
+    getChannel()?.postMessage({ type: 'sync-complete', ts: Date.now() })
+  } catch {
+    // ignore
+  }
+}

--- a/src/sync/storeSyncSubscriptions.ts
+++ b/src/sync/storeSyncSubscriptions.ts
@@ -11,6 +11,12 @@ import { $todayCheckin } from '@/src/stores/checkin.store'
 import { $language } from '@/src/stores/language.store'
 import { $surveyResults } from '@/src/stores/survey.store'
 import { $themeProgressVersion } from '@/src/stores/theme-progress.store'
+import { $topicTestVersion } from '@/src/stores/topic-test.store'
+import {
+  $userStatsVersion,
+  $psychologicalTestStorageVersion,
+  $referralDataVersion,
+} from '@/src/stores/sync-triggers.store'
 import { getSyncService } from '@/utils/supabaseSync/supabaseSyncService'
 import type { SyncDataType } from '@/utils/supabaseSync/types'
 
@@ -40,6 +46,10 @@ export function initStoreSyncSubscriptions(): void {
   onSet($achievementsState, () => queueIfNeeded('achievements'))
   onSet($language, () => queueIfNeeded('preferences'))
   onSet($themeProgressVersion, () => queueIfNeeded('cardProgress'))
+  onSet($userStatsVersion, () => queueIfNeeded('userStats'))
+  onSet($psychologicalTestStorageVersion, () => queueIfNeeded('psychologicalTest'))
+  onSet($referralDataVersion, () => queueIfNeeded('referralData'))
+  onSet($topicTestVersion, () => queueIfNeeded('topicTestResults'))
 
   if (typeof window !== 'undefined') {
     window.setTimeout(() => {

--- a/tests/unit/dirtySignatures.test.ts
+++ b/tests/unit/dirtySignatures.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import {
+  dirtyTypesFromSignatures,
+  signaturesFromPayload,
+  signatureForSyncedValue,
+} from '@/utils/supabaseSync/dirtySignatures'
+import { ALL_SYNCABLE_TYPES } from '@/utils/supabaseSync/syncableTypes'
+import type { SyncDataType } from '@/utils/supabaseSync/types'
+
+const TYPES: readonly SyncDataType[] = ALL_SYNCABLE_TYPES
+
+describe('dirtySignatures', () => {
+  it('signatureForSyncedValue uses absent sentinel for undefined', () => {
+    expect(signatureForSyncedValue(undefined)).toBe('__absent__')
+    expect(signatureForSyncedValue({ a: 1 })).toBe(JSON.stringify({ a: 1 }))
+  })
+
+  it('signaturesFromPayload covers all types', () => {
+    const data = { flowProgress: { step: 1 } } as Record<string, unknown>
+    const sig = signaturesFromPayload(data, TYPES)
+    expect(Object.keys(sig).length).toBe(TYPES.length)
+    expect(sig.flowProgress).toBe(JSON.stringify({ step: 1 }))
+    expect(sig.userStats).toBe('__absent__')
+  })
+
+  it('dirtyTypesFromSignatures is empty when nothing changed', () => {
+    const payload = { userStats: { x: 1 } } as Record<string, unknown>
+    const before = signaturesFromPayload(payload, TYPES)
+    const dirty = dirtyTypesFromSignatures(before, payload, TYPES)
+    expect(dirty.size).toBe(0)
+  })
+
+  it('dirtyTypesFromSignatures includes a type when its value changes', () => {
+    const beforePayload = { userStats: { points: 0 } } as Record<string, unknown>
+    const before = signaturesFromPayload(beforePayload, TYPES)
+    const after = { ...beforePayload, userStats: { points: 1 } } as Record<string, unknown>
+    const dirty = dirtyTypesFromSignatures(before, after, TYPES)
+    expect(dirty.has('userStats')).toBe(true)
+    expect(dirty.size).toBe(1)
+  })
+
+  it('dirtyTypesFromSignatures detects absent to present', () => {
+    const before = signaturesFromPayload({} as Record<string, unknown>, TYPES)
+    const after = { referralData: { code: 'abc' } } as Record<string, unknown>
+    const dirty = dirtyTypesFromSignatures(before, after, TYPES)
+    expect(dirty.has('referralData')).toBe(true)
+  })
+})

--- a/utils/analytics/posthog.ts
+++ b/utils/analytics/posthog.ts
@@ -199,6 +199,7 @@ export const AnalyticsEvent = {
   PAYMENT_FAILED: 'payment_failed',
   PAYMENT_CANCELLED: 'payment_cancelled',
   SYNC_COMPLETE_TTI: 'sync_complete_tti',
+  INCREMENTAL_SYNC_ERROR_SHOWN: 'incremental_sync_error_shown',
   DAILY_CHECKIN_COMPLETED: 'daily_checkin_completed',
   EXPERIMENT_ASSIGNED: 'experiment_assigned',
   TEST_STARTED: 'test_started',

--- a/utils/psychologicalTestStorage.ts
+++ b/utils/psychologicalTestStorage.ts
@@ -1,5 +1,7 @@
 // Утилиты для хранения результатов психологического теста
 
+import { bumpPsychologicalTestSyncVersion } from '@/src/stores/sync-triggers.store';
+
 import { 
   PsychologicalTestResults, 
   PsychologicalTestHistoryEntry,
@@ -42,6 +44,7 @@ export function saveTestResults(
     };
     
     localStorage.setItem(STORAGE_KEY, JSON.stringify(results));
+    bumpPsychologicalTestSyncVersion();
     console.log('Psychological test results saved successfully');
     return true;
   } catch (error) {
@@ -102,6 +105,7 @@ export function loadTestHistory(): PsychologicalTestHistoryEntry[] {
 export function clearTestResults(): void {
   try {
     localStorage.removeItem(STORAGE_KEY);
+    bumpPsychologicalTestSyncVersion();
     console.log('Psychological test results cleared');
   } catch (error) {
     console.error('Failed to clear psychological test results:', error);

--- a/utils/referralUtils.ts
+++ b/utils/referralUtils.ts
@@ -2,6 +2,8 @@
  * Утилиты для работы с реферальной системой
  */
 
+import { bumpReferralDataSyncVersion } from '@/src/stores/sync-triggers.store';
+
 import { getTelegramUserId, isTelegramEnvironment } from './telegramUserUtils';
 import { loadUserStats, saveUserStats } from '../services/userStatsService';
 
@@ -118,6 +120,7 @@ export function saveReferrerInfo(referrerId: string): void {
     // Сохранение реферального кода для истории
     const referralCode = `${REFERRAL_PREFIX}${referrerId}`;
     localStorage.setItem(REFERRAL_CODE_KEY, referralCode);
+    bumpReferralDataSyncVersion();
 
     console.log('Referrer info saved:', { referrerId, referralCode });
   } catch (error) {
@@ -217,6 +220,7 @@ export function generateReferralLink(): string {
 export function markReferralAsRegistered(): void {
   try {
     localStorage.setItem(REFERRAL_REGISTERED_KEY, 'true');
+    bumpReferralDataSyncVersion();
   } catch (error) {
     console.error('Error marking referral as registered:', error);
   }
@@ -286,6 +290,7 @@ export function saveReferralList(referralList: ReferralStorage): void {
   try {
     const key = `${REFERRAL_LIST_PREFIX}${referralList.referrerId}`;
     localStorage.setItem(key, JSON.stringify(referralList));
+    bumpReferralDataSyncVersion();
   } catch (error) {
     console.error('Error saving referral list:', error);
   }

--- a/utils/supabaseSync/dirtySignatures.ts
+++ b/utils/supabaseSync/dirtySignatures.ts
@@ -1,0 +1,37 @@
+import type { SyncDataType } from './types'
+
+const ABSENT = '__absent__'
+
+export function signatureForSyncedValue(v: unknown): string {
+  return v === undefined ? ABSENT : JSON.stringify(v)
+}
+
+/** Stable JSON signatures per syncable type (matches pre-merge snapshot semantics). */
+export function signaturesFromPayload(
+  data: Record<string, unknown>,
+  allTypes: readonly SyncDataType[]
+): Record<string, string> {
+  const sig: Record<string, string> = {}
+  for (const t of allTypes) {
+    const v = data[t]
+    sig[t] = signatureForSyncedValue(v)
+  }
+  return sig
+}
+
+/** Types whose serialized payload changed between `before` signatures and `after` data. */
+export function dirtyTypesFromSignatures(
+  before: Record<string, string>,
+  after: Record<string, unknown>,
+  allTypes: readonly SyncDataType[]
+): Set<SyncDataType> {
+  const dirty = new Set<SyncDataType>()
+  for (const t of allTypes) {
+    const v = after[t]
+    const afterSig = signatureForSyncedValue(v)
+    if (before[t] !== afterSig) {
+      dirty.add(t)
+    }
+  }
+  return dirty
+}

--- a/utils/supabaseSync/supabaseSyncService.ts
+++ b/utils/supabaseSync/supabaseSyncService.ts
@@ -27,6 +27,8 @@ import { bumpTopicTestVersion } from '@/src/stores/topic-test.store';
 import { refreshAllStoresFromStorage } from '../../src/sync/storeHydration';
 import { notifyCrossTabSyncComplete } from '../../src/sync/crossTabSync';
 import { setIncrementalSyncError, setPendingSyncQueueCount } from '@/src/stores/incremental-sync.store';
+import { ALL_SYNCABLE_TYPES } from './syncableTypes';
+import { dirtyTypesFromSignatures, signaturesFromPayload } from './dirtySignatures';
 
 /**
  * Supabase Sync Service Class
@@ -62,20 +64,6 @@ export class SupabaseSyncService {
   private pendingSyncTypes = new Set<SyncDataType>();
   private batchFlushTimer: number | null = null;
   private initializationPromise: Promise<void>;
-
-  private static readonly ALL_SYNCABLE_TYPES: SyncDataType[] = [
-    'surveyResults',
-    'dailyCheckins',
-    'userStats',
-    'achievements',
-    'preferences',
-    'flowProgress',
-    'psychologicalTest',
-    'cardProgress',
-    'referralData',
-    'experimentAssignment',
-    'topicTestResults',
-  ];
 
   private parsePreferencesFromStorage(raw: string): Record<string, any> | null {
     // Try legacy/plain JSON first.
@@ -465,31 +453,18 @@ export class SupabaseSyncService {
    */
   private getAllLocalStorageData(): Record<string, unknown> {
     syncLog.debug('[SyncService] getAllLocalStorageData - Starting data collection');
-    return this.getLocalStorageDataForTypes(new Set(SupabaseSyncService.ALL_SYNCABLE_TYPES));
+    return this.getLocalStorageDataForTypes(new Set(ALL_SYNCABLE_TYPES));
   }
 
   /** Stable JSON signatures per syncable type for dirty detection after merge. */
   private snapshotSyncedPayloadSignatures(): Record<string, string> {
     const data = this.getAllLocalStorageData();
-    const sig: Record<string, string> = {};
-    for (const t of SupabaseSyncService.ALL_SYNCABLE_TYPES) {
-      const v = data[t];
-      sig[t] = v === undefined ? '__absent__' : JSON.stringify(v);
-    }
-    return sig;
+    return signaturesFromPayload(data, ALL_SYNCABLE_TYPES);
   }
 
   private computeDirtyTypesAfterMerge(before: Record<string, string>): Set<SyncDataType> {
     const after = this.getAllLocalStorageData();
-    const dirty = new Set<SyncDataType>();
-    for (const t of SupabaseSyncService.ALL_SYNCABLE_TYPES) {
-      const v = after[t];
-      const afterSig = v === undefined ? '__absent__' : JSON.stringify(v);
-      if (before[t] !== afterSig) {
-        dirty.add(t);
-      }
-    }
-    return dirty;
+    return dirtyTypesFromSignatures(before, after, ALL_SYNCABLE_TYPES);
   }
 
   private enqueueOfflineBatch(types: SyncDataType[], payload: Record<string, unknown>): void {

--- a/utils/supabaseSync/supabaseSyncService.ts
+++ b/utils/supabaseSync/supabaseSyncService.ts
@@ -24,6 +24,9 @@ import { loadSyncPayloadForType } from './buildSyncPayload';
 import { applyRemoteVariantIfStronger } from '../experiment/experimentAssignment';
 import { saveTopicTestResultsMap, type TopicTestResultStored } from '../experiment/topicTestStorage';
 import { bumpTopicTestVersion } from '@/src/stores/topic-test.store';
+import { refreshAllStoresFromStorage } from '../../src/sync/storeHydration';
+import { notifyCrossTabSyncComplete } from '../../src/sync/crossTabSync';
+import { setIncrementalSyncError, setPendingSyncQueueCount } from '@/src/stores/incremental-sync.store';
 
 /**
  * Supabase Sync Service Class
@@ -32,7 +35,8 @@ import { bumpTopicTestVersion } from '@/src/stores/topic-test.store';
  */
 export class SupabaseSyncService {
   private supabase: SupabaseClient | null = null;
-  private syncInProgress = false;
+  /** Serializes initialSync/forceSync so concurrent callers wait instead of failing. */
+  private syncMutex: Promise<void> = Promise.resolve();
   private offlineQueue: SyncQueueItem[] = [];
   private fetchCache: {
     inFlight: Promise<UserDataFromAPI | null> | null;
@@ -44,6 +48,8 @@ export class SupabaseSyncService {
     timestamp: 0,
   };
   private readonly FETCH_CACHE_TTL_MS = 60_000;
+  /** Chrome keepalive requests drop bodies larger than ~64KiB. */
+  private static readonly KEEPALIVE_MAX_BODY_BYTES = 64 * 1024;
   private syncStatus: SyncStatus = {
     isOnline: navigator.onLine,
     lastSync: null,
@@ -198,6 +204,7 @@ export class SupabaseSyncService {
           };
         });
         this.syncStatus.pendingItems = this.offlineQueue.length;
+        setPendingSyncQueueCount(this.offlineQueue.length);
       }
     } catch (error) {
       console.error('Error loading offline queue:', error);
@@ -211,6 +218,7 @@ export class SupabaseSyncService {
     try {
       localStorage.setItem('supabase_sync_queue', JSON.stringify(this.offlineQueue));
       this.syncStatus.pendingItems = this.offlineQueue.length;
+      setPendingSyncQueueCount(this.offlineQueue.length);
     } catch (error) {
       console.error('Error saving offline queue:', error);
     }
@@ -301,19 +309,16 @@ export class SupabaseSyncService {
       await this.syncToSupabase(data);
       this.syncStatus.lastSync = new Date();
       this.syncStatus.syncInProgress = false;
+      setIncrementalSyncError(null);
+      notifyCrossTabSyncComplete();
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
       syncLog.error('[SyncService] batch sync error:', err);
       void captureException(err, { context: 'sync_batch_post', types: Array.from(types).join(',') });
+      setIncrementalSyncError(err.message);
 
       if (this.config.enableOfflineQueue) {
-        this.offlineQueue.push({
-          types: Array.from(types),
-          payload: data,
-          timestamp: new Date(),
-          retryCount: 0,
-        });
-        this.saveOfflineQueue();
+        this.enqueueOfflineBatch(Array.from(types), data);
       }
 
       for (const type of types) {
@@ -328,7 +333,7 @@ export class SupabaseSyncService {
   }
 
   /**
-   * Process offline queue when online
+   * Process offline queue when online (with exponential backoff between retries).
    */
   private async processOfflineQueue(): Promise<void> {
     if (!this.syncStatus.isOnline || this.offlineQueue.length === 0) {
@@ -339,11 +344,19 @@ export class SupabaseSyncService {
     this.offlineQueue = [];
 
     for (const item of itemsToProcess) {
+      const backoffMs =
+        item.retryCount > 0
+          ? Math.min(this.config.retryDelayMs * Math.pow(2, item.retryCount - 1), 30_000)
+          : 0;
+      if (backoffMs > 0) {
+        await new Promise((r) => setTimeout(r, backoffMs));
+      }
       try {
         if (!this.supabase || Object.keys(item.payload).length === 0) {
           continue;
         }
         await this.syncToSupabase(item.payload);
+        setIncrementalSyncError(null);
       } catch {
         if (item.retryCount < this.config.maxRetries) {
           this.offlineQueue.push({
@@ -378,21 +391,28 @@ export class SupabaseSyncService {
       if (Object.keys(data).length === 0) {
         return;
       }
-      void this.flushUnloadWithKeepalive(data);
+      void this.flushUnloadWithKeepalive(data, Array.from(types));
     };
     window.addEventListener('pagehide', run);
     window.addEventListener('beforeunload', run);
   }
 
-  private async flushUnloadWithKeepalive(data: Record<string, unknown>): Promise<void> {
+  private async flushUnloadWithKeepalive(
+    data: Record<string, unknown>,
+    types: SyncDataType[],
+  ): Promise<void> {
     const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
     if (!supabaseUrl) return;
     try {
+      const body = JSON.stringify({ data });
+      if (body.length > SupabaseSyncService.KEEPALIVE_MAX_BODY_BYTES) {
+        this.enqueueOfflineBatch(types, data);
+        return;
+      }
       const jwtToken = await getValidJWTToken();
       const initData = jwtToken ? null : this.getInitData();
       const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY || '';
       const url = `${supabaseUrl}/functions/v1/sync-user-data`;
-      const body = JSON.stringify({ data });
       const headers: Record<string, string> = {
         'Content-Type': 'application/json',
         apikey: anonKey,
@@ -413,7 +433,7 @@ export class SupabaseSyncService {
         keepalive: true,
       });
     } catch {
-      // ignore
+      this.enqueueOfflineBatch(types, data);
     }
   }
 
@@ -446,6 +466,43 @@ export class SupabaseSyncService {
   private getAllLocalStorageData(): Record<string, unknown> {
     syncLog.debug('[SyncService] getAllLocalStorageData - Starting data collection');
     return this.getLocalStorageDataForTypes(new Set(SupabaseSyncService.ALL_SYNCABLE_TYPES));
+  }
+
+  /** Stable JSON signatures per syncable type for dirty detection after merge. */
+  private snapshotSyncedPayloadSignatures(): Record<string, string> {
+    const data = this.getAllLocalStorageData();
+    const sig: Record<string, string> = {};
+    for (const t of SupabaseSyncService.ALL_SYNCABLE_TYPES) {
+      const v = data[t];
+      sig[t] = v === undefined ? '__absent__' : JSON.stringify(v);
+    }
+    return sig;
+  }
+
+  private computeDirtyTypesAfterMerge(before: Record<string, string>): Set<SyncDataType> {
+    const after = this.getAllLocalStorageData();
+    const dirty = new Set<SyncDataType>();
+    for (const t of SupabaseSyncService.ALL_SYNCABLE_TYPES) {
+      const v = after[t];
+      const afterSig = v === undefined ? '__absent__' : JSON.stringify(v);
+      if (before[t] !== afterSig) {
+        dirty.add(t);
+      }
+    }
+    return dirty;
+  }
+
+  private enqueueOfflineBatch(types: SyncDataType[], payload: Record<string, unknown>): void {
+    if (!this.config.enableOfflineQueue || Object.keys(payload).length === 0) {
+      return;
+    }
+    this.offlineQueue.push({
+      types,
+      payload,
+      timestamp: new Date(),
+      retryCount: 0,
+    });
+    this.saveOfflineQueue();
   }
 
   /**
@@ -871,13 +928,12 @@ export class SupabaseSyncService {
     }
     } finally {
       if (typeof window !== 'undefined') {
-        void import('../../src/sync/storeHydration')
-          .then((m) => {
-            m.refreshAllStoresFromStorage();
-          })
-          .catch((err) => {
-            console.warn('[SyncService] refreshAllStoresFromStorage failed:', err);
-          });
+        try {
+          refreshAllStoresFromStorage();
+          notifyCrossTabSyncComplete();
+        } catch (err) {
+          console.warn('[SyncService] refreshAllStoresFromStorage failed:', err);
+        }
       }
     }
   }
@@ -899,21 +955,26 @@ export class SupabaseSyncService {
         errors: [],
       };
     }
-    
-    if (this.syncInProgress) {
-      console.warn('[SyncService] Sync already in progress');
-      void capture(AnalyticsEvent.SYNC_ERROR, {
-        error_message: 'Sync already in progress',
-        reason: 'sync_in_progress',
-        duration_ms: Date.now() - syncStartTime,
-      });
-      return {
-        success: false,
-        syncedTypes: [],
-        errors: [{ type: 'surveyResults', error: 'Sync already in progress' }],
-      };
-    }
 
+    const previous = this.syncMutex;
+    let release!: () => void;
+    this.syncMutex = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+
+    try {
+      this.clearFetchCache();
+      return await this.runInitialSyncImpl(syncStartTime);
+    } finally {
+      release();
+    }
+  }
+
+  /**
+   * Core initial sync (runs under mutex; fetch cache cleared by caller).
+   */
+  private async runInitialSyncImpl(syncStartTime: number): Promise<SyncResult> {
     // Wait for initialization to complete before checking if Supabase is configured
     await this.initializationPromise;
 
@@ -966,7 +1027,6 @@ export class SupabaseSyncService {
     syncLog.debug('[SyncService] Starting initial sync for user ID:', telegramUserId);
     syncLog.debug('[SyncService] Supabase URL:', import.meta.env.VITE_SUPABASE_URL);
 
-    this.syncInProgress = true;
     this.syncStatus.syncInProgress = true;
 
     try {
@@ -976,36 +1036,41 @@ export class SupabaseSyncService {
       syncLog.debug('[SyncService] Remote data check result:', remoteData ? 'User exists' : 'New user');
 
       if (remoteData) {
-        // Existing user: merge remote with local
+        // Existing user: merge remote with local, then push only types that changed
         syncLog.debug('[SyncService] Existing user detected, merging data');
         syncLog.debug('[SyncService] Remote data keys:', Object.keys(remoteData));
+        const beforeSnapshot = this.snapshotSyncedPayloadSignatures();
         this.mergeAndSave(remoteData);
-
-        // Upload merged local data to ensure consistency
-        const localData = this.getAllLocalStorageData();
-        syncLog.debug('[SyncService] Local data keys after merge:', Object.keys(localData));
+        const dirtyTypes = this.computeDirtyTypesAfterMerge(beforeSnapshot);
+        const localData = this.getLocalStorageDataForTypes(dirtyTypes);
+        syncLog.debug('[SyncService] Local data keys after merge (dirty-only):', Object.keys(localData));
         syncLog.debug('[SyncService] Uploading merged data to Supabase in background...');
-        void this.syncToSupabase(localData)
-          .then((uploadResult) => {
-            syncLog.debug('[SyncService] Background upload result:', uploadResult);
-          })
-          .catch((error) => {
-            console.warn('[SyncService] Background upload failed:', error);
-          });
+
+        if (Object.keys(localData).length > 0) {
+          void this.syncToSupabase(localData)
+            .then((uploadResult) => {
+              syncLog.debug('[SyncService] Background upload result:', uploadResult);
+              setIncrementalSyncError(null);
+            })
+            .catch((error) => {
+              console.warn('[SyncService] Background upload failed:', error);
+              const err = error instanceof Error ? error : new Error(String(error));
+              this.enqueueOfflineBatch(Array.from(dirtyTypes), localData);
+              setIncrementalSyncError(err.message);
+            });
+        }
 
         this.syncStatus.lastSync = new Date();
-        this.syncStatus.syncInProgress = false;
-        this.syncInProgress = false;
 
         void capture(AnalyticsEvent.SYNC_SUCCESS, {
           duration_ms: Date.now() - syncStartTime,
-          synced_types: [] as string[],
+          synced_types: Array.from(dirtyTypes) as string[],
           flow: 'existing_user',
         });
 
         return {
           success: true,
-          syncedTypes: [],
+          syncedTypes: Array.from(dirtyTypes),
         };
       } else {
         // New user: upload all local data
@@ -1013,9 +1078,11 @@ export class SupabaseSyncService {
         const localData = this.getAllLocalStorageData();
         syncLog.debug('[SyncService] Local data keys:', Object.keys(localData));
         syncLog.debug('[SyncService] Local data summary:', Object.keys(localData).reduce((acc, key) => {
-          acc[key] = localData[key] ? (typeof localData[key] === 'object' ? Object.keys(localData[key]).length + ' items' : 'present') : 'null';
+          acc[key] = localData[key] ? (typeof localData[key] === 'object' ? Object.keys(localData[key] as object).length + ' items' : 'present') : 'null';
           return acc;
         }, {} as Record<string, string>));
+
+        const uploadedTypes = Object.keys(localData) as SyncDataType[];
 
         // Only upload if there's data to upload
         if (Object.keys(localData).length > 0) {
@@ -1023,27 +1090,28 @@ export class SupabaseSyncService {
           void this.syncToSupabase(localData)
             .then((uploadResult) => {
               syncLog.debug('[SyncService] Background upload result:', uploadResult);
+              setIncrementalSyncError(null);
+              notifyCrossTabSyncComplete();
             })
             .catch((error) => {
               console.warn('[SyncService] Background upload failed:', error);
+              const err = error instanceof Error ? error : new Error(String(error));
+              this.enqueueOfflineBatch(uploadedTypes, localData);
+              setIncrementalSyncError(err.message);
             });
           this.syncStatus.lastSync = new Date();
-          this.syncStatus.syncInProgress = false;
-          this.syncInProgress = false;
           void capture(AnalyticsEvent.SYNC_SUCCESS, {
             duration_ms: Date.now() - syncStartTime,
-            synced_types: [] as string[],
+            synced_types: uploadedTypes as string[],
             flow: 'new_user_upload',
           });
           return {
             success: true,
-            syncedTypes: [],
+            syncedTypes: uploadedTypes,
           };
         } else {
           // No local data, just mark as synced
           this.syncStatus.lastSync = new Date();
-          this.syncStatus.syncInProgress = false;
-          this.syncInProgress = false;
           void capture(AnalyticsEvent.SYNC_SUCCESS, {
             duration_ms: Date.now() - syncStartTime,
             synced_types: [] as string[],
@@ -1057,8 +1125,6 @@ export class SupabaseSyncService {
       }
     } catch (error) {
       console.error('[SyncService] Initial sync failed:', error);
-      this.syncStatus.syncInProgress = false;
-      this.syncInProgress = false;
       const err = error instanceof Error ? error : new Error(String(error));
       void capture(AnalyticsEvent.SYNC_ERROR, {
         error_message: err.message,
@@ -1071,6 +1137,8 @@ export class SupabaseSyncService {
         syncedTypes: [],
         errors: [{ type: 'surveyResults', error: error instanceof Error ? error.message : 'Unknown error' }],
       };
+    } finally {
+      this.syncStatus.syncInProgress = false;
     }
   }
 

--- a/utils/supabaseSync/syncableTypes.ts
+++ b/utils/supabaseSync/syncableTypes.ts
@@ -1,0 +1,16 @@
+import type { SyncDataType } from './types'
+
+/** Types included in merge dirty-detection and full local snapshot collection. */
+export const ALL_SYNCABLE_TYPES: readonly SyncDataType[] = [
+  'surveyResults',
+  'dailyCheckins',
+  'userStats',
+  'achievements',
+  'preferences',
+  'flowProgress',
+  'psychologicalTest',
+  'cardProgress',
+  'referralData',
+  'experimentAssignment',
+  'topicTestResults',
+]


### PR DESCRIPTION
# Sync Architecture Audit and Fix Plan

## Current Architecture Summary

```mermaid
flowchart TD
    subgraph frontend [Frontend - Browser]
        UI[React Components]
        NS[Nanostores]
        LS[localStorage]
        SS[SupabaseSyncService]
        OQ[Offline Queue]
        RQ[Reward Offline Queue]
    end
    subgraph backend [Backend - Supabase Edge Functions]
        GUD[get-user-data]
        SUD[sync-user-data]
        GR[grant-reward]
        DB[(PostgreSQL)]
    end

    UI -->|useStore| NS
    NS -->|onSet via storeSyncSubscriptions| SS
    NS -->|read/write| LS
    SS -->|pull: GET| GUD
    SS -->|push: POST| SUD
    SS -->|offline fallback| OQ
    GUD -->|SELECT/RPC| DB
    SUD -->|UPSERT| DB
    GR -->|RPC| DB
    SS -->|mergeAndSave| LS
    LS -->|refreshAllStoresFromStorage| NS
```



**Sync model:** Local-first with custom pull/push via raw `fetch` to Supabase Edge Functions. No React Query, no Supabase Realtime, no WebSockets/SSE. Nanostores as UI state, localStorage as persistence, `SupabaseSyncService` as orchestrator.

---

## 1. Sync Issues Report

### P0 -- Critical

**Issue 1: `forceSync` returns cached data (stale pull on foreground)**

- **File:** `[utils/supabaseSync/supabaseSyncService.ts](utils/supabaseSync/supabaseSyncService.ts)` lines 1080-1082, 469-475
- **Root cause:** `forceSync()` calls `initialSync()` which calls `fetchFromSupabase()` -- but `fetchFromSupabase` has a 60s in-memory cache (`FETCH_CACHE_TTL_MS`). The cache is never cleared before a force sync.
- **Impact:** When user returns from background (visibility change), the pull may return cached data from up to 60s ago. Data from other devices or backend-side changes (e.g., payment webhook) will be invisible.
- **Fix:** Clear `fetchCache` at the top of `initialSync()` and in a new `pullOnly()` method for the visibility handler.

**Issue 2: `initialSync` guard blocks concurrent forceSync with no recovery**

- **File:** `[utils/supabaseSync/supabaseSyncService.ts](utils/supabaseSync/supabaseSyncService.ts)` lines 903-915
- **Root cause:** If `syncInProgress === true`, the call returns `{ success: false }` immediately with no retry or wait mechanism. The visibility-triggered `forceSync` is permanently dropped.
- **Impact:** If the user opens the app and switches away/back before initial sync completes, the foreground refresh is lost. Premium purchases or data from other sessions can be missed.
- **Fix:** Instead of rejecting, queue a "sync requested" flag and re-run after the current sync completes. Alternatively, have the visibility handler await the in-progress sync promise.

**Issue 3: Missing sync push subscriptions for 4+ data types**

- **File:** `[src/sync/storeSyncSubscriptions.ts](src/sync/storeSyncSubscriptions.ts)` -- only 6 of 11 syncable types are subscribed
- **Missing:** `userStats`, `psychologicalTest`, `referralData`, `topicTestResults`
- **Root cause:** These data types don't have corresponding Nanostores with `onSet` subscriptions
- **Impact:** Changes to psychological test results, user stats, referral data, and topic test results only reach the server on the next full app restart sync. Risk of data loss if the user doesn't reopen the app.
- **Fix:** Add store atoms or direct localStorage-change listeners for these types.

**Issue 4: Async store refresh after merge creates race condition**

- **File:** `[utils/supabaseSync/supabaseSyncService.ts](utils/supabaseSync/supabaseSyncService.ts)` lines 873-882
- **Root cause:** `mergeAndSave()` uses `void import('../../src/sync/storeHydration')` (dynamic import, fire-and-forget) for `refreshAllStoresFromStorage()`. The `hydratingFromMerge` guard may not be active when the caller in `[AppContent.tsx](AppContent.tsx)` line 187 calls `refreshFlowProgress()` immediately after sync.
- **Impact:** Store subscription handlers in `storeSyncSubscriptions.ts` may fire during manual refresh (without hydration guard), causing the just-merged remote data to be pushed BACK to the server as a "change" -- a wasteful echo sync cycle.
- **Fix:** Make `mergeAndSave` call `refreshAllStoresFromStorage` synchronously (the module is already loaded at this point; dynamic import is unnecessary) or return a promise the caller can await.

### P1 -- High Priority

**Issue 5: Background upload after merge is fire-and-forget**

- **File:** `[utils/supabaseSync/supabaseSyncService.ts](utils/supabaseSync/supabaseSyncService.ts)` lines 988-994
- **Root cause:** `void this.syncToSupabase(localData)` -- upload failure is silently swallowed
- **Impact:** Server can retain stale data. If the merge produced new merged values (e.g., union of local + remote achievements), the server never gets them.
- **Fix:** Push to offline queue on failure; add retry logic similar to `flushPendingBatchSync`.

**Issue 6: Full snapshot pushed on every app open**

- **File:** `[utils/supabaseSync/supabaseSyncService.ts](utils/supabaseSync/supabaseSyncService.ts)` lines 985-988
- **Root cause:** After merge, `getAllLocalStorageData()` collects ALL 11 types and pushes them unconditionally
- **Impact:** Unnecessary bandwidth; ~5-50KB per app open depending on user data. On slow mobile connections, this delays the sync response.
- **Fix:** Only push types that were actually modified during merge (compare pre/post merge snapshots or use dirty-tracking).

**Issue 7: No backoff in offline queue processing**

- **File:** `[utils/supabaseSync/supabaseSyncService.ts](utils/supabaseSync/supabaseSyncService.ts)` lines 333-358
- **Root cause:** `processOfflineQueue` iterates and retries all items sequentially without delay
- **Impact:** On flaky connections, rapid-fire requests that all fail, wasting battery and bandwidth
- **Fix:** Add exponential backoff between retries.

**Issue 8: `keepalive` flush silently fails for large payloads**

- **File:** `[utils/supabaseSync/supabaseSyncService.ts](utils/supabaseSync/supabaseSyncService.ts)` lines 387-418
- **Root cause:** `keepalive: true` has a ~64KB body size limit in Chrome. Error is caught and ignored.
- **Impact:** Data loss on page close if payload exceeds limit.
- **Fix:** Measure payload size before sending; if too large, prioritize critical types or split into smaller payloads. Fall back to offline queue for oversized payloads.

### P2 -- Medium Priority

**Issue 9: No cross-tab synchronization**

- No `BroadcastChannel`, `SharedWorker`, or systematic `storage` event listeners
- Only `menhausen_user_stats` key triggers cross-tab behavior (achievement checks)
- **Impact:** Two open tabs show divergent data until reload
- **Fix:** Add a `BroadcastChannel` that signals sync completion; receiving tabs call `refreshAllStoresFromStorage`.

**Issue 10: Incremental sync errors invisible to users**

- `$syncError` atom only captures `initSync` errors. Batched sync errors in `syncStatus.errors[]` are internal only.
- **Fix:** Expose `$incrementalSyncError` atom; optionally show toast on repeated failures.

**Issue 11: Premium activation eventual consistency window**

- 1-second `setTimeout` before signature verification after `premium:activated` event
- **Fix:** Reduce delay; immediately attempt signature fetch instead of waiting.

### P3 -- Low Priority

**Issue 12:** Verbose `console.log` / `syncLog.debug` in production hot paths (conflict resolver, merge logic)
**Issue 13:** `synced_types: []` always empty in `SYNC_SUCCESS` analytics events
**Issue 14:** Redundant store refreshes after merge (async + manual)

---

## 2. Architecture Improvements

### Recommended Sync Model Enhancements

```mermaid
flowchart TD
    subgraph improved [Improved Sync Flow]
        A[Store Change] -->|onSet| B[storeSyncSubscriptions]
        B -->|queueSync type| C[Batched Debounce 500ms]
        C -->|POST partial| D[sync-user-data]
        
        E[App Open] -->|clearCache + pull| F[get-user-data]
        F -->|mergeAndSave sync| G[refreshAllStores]
        G -->|dirty-only push| D
        
        H[Visibility Visible] -->|awaitOrQueue| I{Sync In Progress?}
        I -->|Yes| J[Wait + Re-pull]
        I -->|No + Stale| F
        
        K[Online Event] -->|processOfflineQueue| L[Exponential Backoff]
        L --> D
        
        M[BroadcastChannel] -->|sync-complete| N[Other Tabs Refresh]
    end
```



**Key changes:**

1. **Synchronous store hydration** -- Replace dynamic import with direct call in `mergeAndSave`
2. **Dirty-only push after merge** -- Track which types changed during merge; only push those
3. **Awaitable sync guard** -- Instead of rejecting concurrent syncs, expose a promise for callers to await
4. `**BroadcastChannel` for cross-tab** -- Lightweight; widely supported; no server cost
5. **Exponential backoff** -- For offline queue and retry logic
6. **Missing store subscriptions** -- Add `onSet` listeners for `userStats`, `psychologicalTest`, `topicTestResults`, `referralData`

---

## 3. Code Changes

### File-by-file summary


| File                                                                                     | Changes                                                                                                                                                                                                                                                                                                                |
| ---------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `[utils/supabaseSync/supabaseSyncService.ts](utils/supabaseSync/supabaseSyncService.ts)` | Clear fetch cache in `initialSync`/`forceSync`; replace `syncInProgress` boolean with awaitable promise; make `mergeAndSave` call hydration synchronously; add dirty-tracking to post-merge push; add exponential backoff to offline queue; add payload size check in keepalive flush; queue failed background uploads |
| `[src/sync/storeSyncSubscriptions.ts](src/sync/storeSyncSubscriptions.ts)`               | Add `onSet` for missing types (`$psychologicalTestAnswers`, `$topicTestVersion`, referral/stats atoms or direct localStorage listeners)                                                                                                                                                                                |
| `[src/sync/storeHydration.ts](src/sync/storeHydration.ts)`                               | No structural changes (already correct); verify import is used synchronously from `mergeAndSave`                                                                                                                                                                                                                       |
| `[src/utils/visibilitySync.ts](src/utils/visibilitySync.ts)`                             | No changes needed                                                                                                                                                                                                                                                                                                      |
| `[AppContent.tsx](AppContent.tsx)`                                                       | Update `forceSync` usage to await in-progress sync; remove redundant `refreshFlowProgress()` after sync (handled by synchronous hydration)                                                                                                                                                                             |
| `[src/stores/sync.store.ts](src/stores/sync.store.ts)`                                   | Expose `$pendingSyncCount` atom; add `awaitCurrentSync()` helper                                                                                                                                                                                                                                                       |
| `[src/stores/premium.store.ts](src/stores/premium.store.ts)`                             | Reduce premium activation delay from 1s to immediate                                                                                                                                                                                                                                                                   |
| New: `[src/sync/crossTabSync.ts](src/sync/crossTabSync.ts)`                              | `BroadcastChannel` wrapper: emit on sync complete, listen and refresh stores                                                                                                                                                                                                                                           |


---

## 4. Follow-up Recommendations

- **Supabase Realtime subscription** -- For premium status changes and payment webhooks, a Supabase Realtime channel would eliminate polling entirely. Deferred since it requires backend changes.
- **React Query adoption** -- Not recommended now (would require major refactoring of Nanostores architecture). The custom sync service is functional; fixing the identified gaps is more pragmatic.
- **Incremental sync versioning** -- Add a `sync_version` or `last_modified_at` per data type in the DB, so the client can request only changed types. Significant backend change; deferred.
- **Payload compression** -- For the keepalive flush and large sync payloads, consider `CompressionStream` API or reducing payload size by diffing against last-known server state.
- **Offline-first service worker** -- For true offline support with background sync. Lower priority since this is primarily a Telegram WebApp (always online).

