### PR TITLE
Identify Before EXPRMNT run

### DIFF
--- a/AppContent.tsx
+++ b/AppContent.tsx
@@ -211,6 +211,8 @@ function AppContent() {
       if (userId && userId !== '111') {
         const v: ExperimentVariantType = assignVariant(userId)
         $experimentVariant.set(v)
+        // Identify before experiment_assigned so person.experiment_variant is set for person-level breakdowns
+        void identify(userId)
         const w = typeof window !== 'undefined' ? (window as any) : undefined
         if (w && !w.__EXPERIMENT_ASSIGNED_SENT) {
           w.__EXPERIMENT_ASSIGNED_SENT = true
@@ -219,7 +221,6 @@ function AppContent() {
             variant: v,
           })
         }
-        void identify(userId)
         try {
           getSyncService().queueSync('experimentAssignment')
         } catch {

--- a/utils/analytics/posthog.ts
+++ b/utils/analytics/posthog.ts
@@ -70,10 +70,23 @@ export function capture(eventName: string, properties?: Record<string, any>): vo
     const defaultEventProps = { source: 'web' }
     const uid = getTelegramUserId()
     const variant = $experimentVariant.get()
+    const experimentProps =
+      variant
+        ? {
+            variant,
+            experiment_variant: variant,
+            experiment_key: EXPERIMENT.KEY_ONBOARDING_FLOW_V1,
+            // Same payload as identify(); avoids person.experiment_variant lag vs events (PostHog breakdowns).
+            $set: {
+              experiment_variant: variant,
+              experiment_key: EXPERIMENT.KEY_ONBOARDING_FLOW_V1,
+            },
+          }
+        : {}
     posthog.capture(eventName, {
       ...defaultEventProps,
       ...(uid ? { user_id: uid } : {}),
-      ...(variant ? { variant } : {}),
+      ...experimentProps,
       ...(properties || {}),
     })
   } catch {


### PR DESCRIPTION
In AppContent.tsx, identify(userId) runs before capture(EXPERIMENT_ASSIGNED) so person.experiment_variant is set before the assignment event is sent, which should shrink the null person bucket on new sessions. capture() still sends variant on events via the store.