### PR TITLE
UTM Attribution

### DIFF
--- a/AppContent.tsx
+++ b/AppContent.tsx
@@ -14,6 +14,8 @@ import { capture, AnalyticsEvent, identify } from './src/effects/analytics.effec
 import { initScreenViewTracking } from './src/effects/screen-view.effect'
 import { getTelegramUserId } from './utils/telegramUserUtils'
 import { processReferralCode, updateReferrerStatsFromList } from './utils/referralUtils'
+import { getAttributionFromStartParam } from './utils/attribution'
+import { setAttributionData } from './utils/analytics/posthog'
 import { hasTestBeenCompleted } from './utils/psychologicalTestStorage'
 import { AppScreen } from './types/userState'
 import {
@@ -100,6 +102,10 @@ function AppContent() {
   }, [])
 
   useEffect(() => {
+    const attribution = getAttributionFromStartParam()
+    if (attribution) {
+      setAttributionData(attribution)
+    }
     processReferralCode()
     updateReferrerStatsFromList()
   }, [])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.2.90] - 2026-04-16
+
+### Added
+- **UTM Attribution**: Track user acquisition source from external links. When users open the Mini App via link with `?start=<base64>` parameter, UTM data (source, medium, campaign, referrer) is extracted and sent to PostHog for analytics.
+
+### Fixed
+- Fixed vulnerability in follow-redirects dependency (moderate severity)
+
+### Changed
+- Improved experiment assignment timing - identify called before experiment_assigned event for accurate person-level breakdowns in PostHog
+- Fixed duplicate experiment assignment events
+
+## [1.2.89] - 2026-04-15
+
+### Added
+- **Fast Mental Help**: New "Rapid Techniques" flow for quick mental health exercises (4-6 breathing, grounding)
+
+### Fixed
+- Various bug fixes and improvements
+
+## [1.2.88] - 2026-04-14
+
+### Added
+- **Sync Architecture Audit**: Multiple improvements to data synchronization
+  - Fetch cache cleared before initial/force sync
+  - Mutex serializes concurrent syncs
+  - Cross-tab sync with BroadcastChannel
+  - Incremental sync error surfaced in UI
+
+### Fixed
+- Fixed redundant refreshes after sync hydration
+- Analytics synced_types populated with actual types

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Menhausen Telegram Mini App
 
+[![Version](https://img.shields.io/badge/version-1.2.90-blue.svg)](https://github.com/imfineapp/menhausen_app/releases)
+
 A comprehensive mental health support application built as a Telegram Mini App, featuring personalized exercises, mood tracking, and evidence-based psychological techniques.
 
 ## 🚀 Quick Start
@@ -495,6 +497,7 @@ const observer = new PerformanceObserver((list) => {
 ## 📞 Support
 
 ### Documentation
+- **Changelog**: [CHANGELOG.md](./CHANGELOG.md) - Release history and updates
 - **Design Guidelines**: `/guidelines/Guidelines.md`
 - **Technical Spec**: `/specification.md`
 - **API Documentation**: Coming with backend integration

--- a/docs/utm-attribution-implementation.md
+++ b/docs/utm-attribution-implementation.md
@@ -1,0 +1,183 @@
+# UTM Attribution Implementation Plan
+
+## Goal
+
+Track user acquisition source in PostHog by extracting UTM parameters from Telegram Mini App start parameter.
+
+## Context
+
+When users open the Mini App via link like `https://t.me/menhausen_app_bot/app?start=eyJzIjoiZmFjZWJvb2siLCJ0IjoxNzc2MjcwOTkwLCJ2IjoxfQ`:
+
+1. Extract `start` parameter from URL (`tgWebAppStartParam`)
+2. Decode base64url → JSON: `{s, m, c, r, t, v}`
+3. Map to UTM fields: `s`→utm_source, `m`→utm_medium, `c`→utm_campaign, `r`→utm_referrer
+4. Initialize PostHog with user ID as distinct_id
+5. On `identify()`: pass utm_* as person properties
+6. On every `track()`: include utm_* in properties
+
+## Edge Case: Referral codes
+
+Existing referral system uses `?startapp=REF_123456`. Need to differentiate:
+
+- `start.startsWith('REF_')` → referral code (existing logic)
+- base64-decodable JSON with `t, v` → UTM attribution (new logic)
+
+---
+
+## Implementation Steps
+
+### Step 1: Create `utils/attribution.ts`
+
+```typescript
+interface AttributionData {
+  utm_source?: string;
+  utm_medium?: string;
+  utm_campaign?: string;
+  utm_referrer?: string;
+  attribution_timestamp: number;
+  attribution_version: number;
+}
+
+// Decode base64url to JSON
+function decodeBase64Url(encoded: string): string {
+  const base64 = encoded.replace(/-/g, '+').replace(/_/g, '/')
+  return atob(base64)
+}
+
+// Parse attribution from start param
+export function getAttributionFromStartParam(): AttributionData | null {
+  // 1. Get start_param from Telegram or URL
+  // 2. Check if it's NOT a referral code (doesn't start with REF_)
+  // 3. Try to decode as base64 → JSON
+  // 4. Validate presence of 't' and 'v' fields
+  // 5. Map s→utm_source, m→utm_medium, c→utm_campaign, r→utm_referrer
+  // 6. Console.log debug info
+}
+```
+
+### Step 2: Update `utils/referralUtils.ts`
+
+Modify `getReferralCodeFromStartParam()`:
+- If param starts with `REF_` → return referral code (existing)
+- If param is valid UTM JSON → return `null` (UTM handled separately)
+- If neither → return `null`
+
+Add `processAttribution()` wrapper that calls `getAttributionFromStartParam()` and returns data.
+
+### Step 3: Update `utils/analytics/posthog.ts`
+
+```typescript
+// Module-level variable to store attribution
+let storedAttribution: AttributionData | null = null
+
+export function setAttributionData(data: AttributionData): void {
+  storedAttribution = data
+}
+
+export function capture(eventName: string, properties?: Record<string, any>): void {
+  // ... existing logic
+  const utmProps = storedAttribution ? {
+    utm_source: storedAttribution.utm_source,
+    utm_medium: storedAttribution.utm_medium,
+    utm_campaign: storedAttribution.utm_campaign,
+    utm_referrer: storedAttribution.utm_referrer,
+  } : {}
+  
+  posthog.capture(eventName, {
+    ...defaultEventProps,
+    ...uidProps,
+    ...experimentProps,
+    ...utmProps,  // ← Add UTM to all events
+    ...(properties || {}),
+  })
+}
+
+export function identify(distinctId: string, properties?: Record<string, any>): void {
+  // ... existing logic
+  const utmProps = storedAttribution ? {
+    utm_source: storedAttribution.utm_source,
+    utm_medium: storedAttribution.utm_medium,
+    utm_campaign: storedAttribution.utm_campaign,
+    utm_referrer: storedAttribution.utm_referrer,
+  } : {}
+  
+  posthog.identify(distinctId, {
+    ...defaultProps,
+    ...utmProps,  // ← Add UTM to person properties
+    ...(properties || {}),
+  })
+}
+```
+
+### Step 4: Integrate in `AppContent.tsx`
+
+```typescript
+// At app initialization (before processReferralCode):
+const startParam = getStartParamFromUrl()
+const attribution = getAttributionFromStartParam()
+
+// Debug console output
+console.log('[Attribution] Full start param:', startParam)
+console.log('[Attribution] Decoded attribution:', attribution)
+console.log('[Attribution] Referral code:', referralCode)
+
+if (attribution) {
+  setAttributionData(attribution)
+}
+
+// Existing referral processing
+processReferralCode()
+
+// Identify with UTM (utm_* added automatically)
+if (userId) {
+  identify(userId)
+}
+```
+
+---
+
+## Files to Modify
+
+| File | Action |
+|------|--------|
+| `utils/attribution.ts` | **Create** |
+| `utils/referralUtils.ts` | Update type detection logic |
+| `utils/analytics/posthog.ts` | Add UTM to capture/identify |
+| `AppContent.tsx` | Initialize attribution at startup |
+
+---
+
+## PostHog Data Flow
+
+1. **Person properties** (on identify):
+   - `utm_source`
+   - `utm_medium`
+   - `utm_campaign`
+   - `utm_referrer`
+
+2. **Event properties** (on every capture):
+   - `utm_source`
+   - `utm_medium`
+   - `utm_campaign`
+   - `utm_referrer`
+
+---
+
+## Console Debug Output
+
+```
+[Attribution] Start param: eyJzIjoiZmFjZWJvb2siLCJ0IjoxNzc2MjcwOTkwLCJ2IjoxfQ
+[Attribution] Decoded: { s: "facebook", m: "cpc", c: "summer", r: "facebook.com", t: 1776270990, v: 1 }
+[Attribution] Attribution data: { utm_source: "facebook", utm_medium: "cpc", utm_campaign: "summer", utm_referrer: "facebook.com", ... }
+[Attribution] Referral code: null (detected as UTM, not REF_*)
+```
+
+---
+
+## Testing Checklist
+
+- [ ] Open app with `?start=eyJzIjoiZmFjZWJvb2si...` — attribution extracted
+- [ ] Open app with `?startapp=REF_123456` — referral works (existing)
+- [ ] Open app without start param — no errors
+- [ ] PostHog identify includes utm_* as person properties
+- [ ] PostHog capture includes utm_* in event properties

--- a/docs/utm-link-generation.md
+++ b/docs/utm-link-generation.md
@@ -1,0 +1,92 @@
+# Telegram Mini App: передача UTM-параметров
+
+## Проблема
+
+При открытии Mini App через Direct Link с UTM-параметрами нужно отслеживать источник пользователя. Однако Telegram передаёт параметры специфичным образом.
+
+## Решение
+
+### Формат ссылки
+
+Использовать **`?startapp=`** (не `?start=`):
+
+```
+https://t.me/mnhsn_staging_bot/app?startapp=eyJzIjoiZmFjZWJvb2siLCJ0IjoxNzc2MjcwOTkwLCJ2IjoxfQ
+```
+
+### Генерация UTM-параметров
+
+1. Создать JSON с данными:
+```json
+{
+  "s": "facebook",   // utm_source
+  "t": 1776270990, // timestamp (unixtime)
+  "v": 1          // version
+}
+```
+
+2. Закодировать в base64url:
+```javascript
+// JavaScript
+const data = JSON.stringify({ s: 'facebook', t: Math.floor(Date.now() / 1000), v: 1 })
+const base64 = btoa(data).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '')
+```
+
+3. Добавить к ссылке:
+```
+https://t.me/mnhsn_staging_bot/app?startapp=<base64>
+```
+
+### Полный список полей
+
+| Поле | Описание | Пример |
+|------|----------|--------|
+| `s` | utm_source | `facebook`, `google`, `instagram` |
+| `m` | utm_medium | `cpc`, `email`, `organic` |
+| `c` | utm_campaign | `summer_sale`, `onboarding` |
+| `r` | referrer (domain) | `facebook.com` |
+| `t` | timestamp | `1776270990` |
+| `v` | version (всегда 1) | `1` |
+
+### Примеры ссылок
+
+**Только source:**
+```
+https://t.me/mnhsn_staging_bot/app?startapp=eyJzIjoiZ29vZ2xlIiwidCI6MTc3NjI3MDk5MCwidjEiF0
+```
+
+**Полная атрибуция:**
+```
+https://t.me/mnhsn_staging_bot/app?startapp=eyJzIjoiZmFjZWJvb2siLCJtIjoiY3BjIiwiYyI6InN1bW1lcl9zYWxlIiwiciI6ImZhY2Vib29rLmNvbSIsInQiOjE3NzYyNzAwOTkwLCJ2IjoxfQ
+```
+
+## Где отслеживать
+
+- **PostHog**: `utm_source`, `utm_medium`, `utm_campaign`, `utm_referrer` автоматически добавляются к:
+  - Person properties (при identify)
+  - Event properties (при каждом track)
+
+- **Console**: При запуске приложения логируется:
+```
+[Attribution] Start param: <значение>
+[Attribution] Decoded attribution: <данные>
+[Attribution] Attribution data: <распарсенные данные>
+```
+
+## Ограничения
+
+- **Только `?startapp=`**: Параметр `?start=` **НЕ работает** для Direct Links
+- **Direct Links vs Attachment Menu**: Для attachment menu параметры передаются иначе
+- **Base64url**: Использовать base64url encoding (заменить `+` на `-`, `/` на `_`)
+
+## Тестирование
+
+```bash
+# Скопировать ссылку в буфер обмена
+# Открыть в Telegram
+# Проверить консоль браузера
+```
+
+## Длина
+
+Максимум 512 символов для `startapp` параметра.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "menhausen-telegram-mini-app",
-  "version": "1.2.89",
+  "version": "1.2.90",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "menhausen-telegram-mini-app",
-      "version": "1.2.89",
+      "version": "1.2.90",
       "dependencies": {
         "@floating-ui/react": "^0.26.0",
         "@nanostores/i18n": "^1.2.2",
@@ -6412,9 +6412,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "menhausen-telegram-mini-app",
-  "version": "1.2.88",
+  "version": "1.2.89",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "menhausen-telegram-mini-app",
-      "version": "1.2.88",
+      "version": "1.2.89",
       "dependencies": {
         "@floating-ui/react": "^0.26.0",
         "@nanostores/i18n": "^1.2.2",
@@ -7277,9 +7277,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "menhausen-telegram-mini-app",
   "private": true,
-  "version": "1.2.89",
+  "version": "1.2.90",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/utils/analytics/posthog.ts
+++ b/utils/analytics/posthog.ts
@@ -4,9 +4,45 @@ import type { PostHogConfig } from 'posthog-js'
 import { $experimentVariant } from '@/src/stores/experiment.store'
 import { EXPERIMENT } from '@/utils/experiment/experimentKeys'
 import { getTelegramUserId } from '@/utils/telegramUserUtils'
+import type { AttributionData } from '@/utils/attribution'
 
 /** Singleton used by PostHogProvider (`client={posthog}`) and non-React code (stores, services). */
 export { posthog }
+
+/** Module-level storage for UTM attribution data */
+let storedAttribution: AttributionData | null = null
+
+/**
+ * Сохранить UTM атрибуцию для использования в capture() и identify()
+ * @param {AttributionData | null} data - Данные атрибуции или null для очистки
+ */
+export function setAttributionData(data: AttributionData | null): void {
+  storedAttribution = data
+}
+
+/**
+ * Получить сохранённые UTM данные
+ * @returns {AttributionData | null} Сохранённые данные атрибуции
+ */
+export function getAttributionData(): AttributionData | null {
+  return storedAttribution
+}
+
+/**
+ * Сформировать UTM свойства для PostHog events
+ * @returns {Record<string, string>} Объект с utm_* полями
+ */
+function getUtmProps(): Record<string, string> {
+  if (!storedAttribution) {
+    return {}
+  }
+  return {
+    utm_source: storedAttribution.utm_source || '',
+    utm_medium: storedAttribution.utm_medium || '',
+    utm_campaign: storedAttribution.utm_campaign || '',
+    utm_referrer: storedAttribution.utm_referrer || '',
+  }
+}
 
 function getEnv(key: string): string | undefined {
   try {
@@ -83,10 +119,12 @@ export function capture(eventName: string, properties?: Record<string, any>): vo
             },
           }
         : {}
+    const utmProps = getUtmProps()
     posthog.capture(eventName, {
       ...defaultEventProps,
       ...(uid ? { user_id: uid } : {}),
       ...experimentProps,
+      ...utmProps,
       ...(properties || {}),
     })
   } catch {
@@ -140,7 +178,8 @@ export function identify(distinctId: string, properties?: Record<string, any>): 
       defaultProps.experiment_key = EXPERIMENT.KEY_ONBOARDING_FLOW_V1
     }
 
-    const mergedProps = { ...defaultProps, ...(properties || {}) }
+    const utmProps = getUtmProps()
+    const mergedProps = { ...defaultProps, ...utmProps, ...(properties || {}) }
 
     posthog.identify(distinctId, mergedProps)
   } catch {

--- a/utils/attribution.ts
+++ b/utils/attribution.ts
@@ -1,0 +1,178 @@
+/**
+ * Утилиты для UTM атрибуции
+ * Извлекает UTM параметры из start параметра Telegram Mini App
+ */
+
+import { isTelegramEnvironment } from './telegramUserUtils';
+
+export interface AttributionData {
+  utm_source?: string;
+  utm_medium?: string;
+  utm_campaign?: string;
+  utm_referrer?: string;
+  attribution_timestamp: number;
+  attribution_version: number;
+}
+
+const REFERRAL_PREFIX = 'REF_';
+
+/**
+ * Декодировать base64url строку в JSON
+ * @param {string} encoded - base64url закодированная строка
+ * @returns {string} Декодированная JSON строка
+ */
+function decodeBase64Url(encoded: string): string {
+  const base64 = encoded.replace(/-/g, '+').replace(/_/g, '/')
+  return atob(base64)
+}
+
+/**
+ * Парсить JSON строку в объект
+ * @param {string} jsonString - JSON строка
+ * @returns {Record<string, any> | null} Распарсенный объект или null при ошибке
+ */
+function parseJsonSafe(jsonString: string): Record<string, any> | null {
+  try {
+    return JSON.parse(jsonString)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Проверить, является ли параметр реферальным кодом
+ * @param {string | null} param - Параметр из URL
+ * @returns {boolean} True если это реферальный код (начинается с REF_)
+ */
+function isReferralCode(param: string | null): boolean {
+  return param !== null && param.startsWith(REFERRAL_PREFIX)
+}
+
+/**
+ * Валидировать что объект содержит минимально необходимые поля для UTM атрибуции
+ * @param {Record<string, any>} obj - Распарсенный объект
+ * @returns {boolean} True если содержит поля t (timestamp) и v (version)
+ */
+function isValidAttribution(obj: Record<string, any>): boolean {
+  return (
+    obj !== null &&
+    typeof obj === 'object' &&
+    typeof obj.t === 'number' &&
+    typeof obj.v === 'number'
+  )
+}
+
+/**
+ * Конвертировать внутренние поля в UTM поля
+ * @param {Record<string, any>} obj - Распарсенный объект из base64
+ * @returns {AttributionData} Объект атрибуции с UTM полями
+ */
+function convertToAttribution(obj: Record<string, any>): AttributionData {
+  return {
+    utm_source: obj.s,
+    utm_medium: obj.m,
+    utm_campaign: obj.c,
+    utm_referrer: obj.r,
+    attribution_timestamp: obj.t,
+    attribution_version: obj.v,
+  }
+}
+
+/**
+ * Получить start параметр из Telegram WebApp или URL
+ * @returns {string | null} Значение start параметра или null
+ */
+function getStartParam(): string | null {
+  try {
+    const isTg = isTelegramEnvironment()
+    if (!isTg) {
+      return null
+    }
+
+    // Метод 1: Получить из initDataUnsafe.start_param
+    const webAppStartParam = window.Telegram?.WebApp?.initDataUnsafe?.start_param
+    if (webAppStartParam) {
+      return webAppStartParam
+    }
+
+    // Метод 2: Получить из URL параметров
+    const urlParams = new URLSearchParams(window.location.search)
+    const startParam = urlParams.get('start') || urlParams.get('startapp') || urlParams.get('tgWebAppStartParam')
+    if (startParam) {
+      return startParam
+    }
+
+    return null
+  } catch (error) {
+    console.warn('[Attribution] Error getting start param:', error)
+    return null
+  }
+}
+
+/**
+ * Получить UTM атрибуцию из start параметра
+ * @returns {AttributionData | null} Данные атрибуции или null если не найдены
+ */
+export function getAttributionFromStartParam(): AttributionData | null {
+  try {
+    const startParam = getStartParam()
+
+    // Debug: выводим весь start параметр
+    console.log('[Attribution] Start param:', startParam)
+
+    // Нет параметра
+    if (!startParam) {
+      console.log('[Attribution] No start param found')
+      return null
+    }
+
+    // Это реферальный код - не UTM атрибуция
+    if (isReferralCode(startParam)) {
+      console.log('[Attribution] Detected as referral code, not UTM attribution')
+      return null
+    }
+
+    // Пробуем декодировать как base64
+    let decoded: string
+    try {
+      decoded = decodeBase64Url(startParam)
+    } catch {
+      console.log('[Attribution] Not base64 encoded, treating as regular start param')
+      return null
+    }
+
+    // Парсим JSON
+    const parsed = parseJsonSafe(decoded)
+    if (!parsed) {
+      console.log('[Attribution] Not valid JSON, treating as regular start param')
+      return null
+    }
+
+    // Валидируем что это UTM атрибуция (есть t и v)
+    if (!isValidAttribution(parsed)) {
+      console.log('[Attribution] No valid attribution fields (t, v), treating as regular start param')
+      return null
+    }
+
+    // Конвертируем в формат атрибуции
+    const attribution = convertToAttribution(parsed)
+
+    console.log('[Attribution] Decoded attribution:', parsed)
+    console.log('[Attribution] Attribution data:', attribution)
+
+    return attribution
+  } catch (error) {
+    console.error('[Attribution] Error parsing attribution:', error)
+    return null
+  }
+}
+
+/**
+ * Проверить, является ли start параметр реферальным кодом
+ * Используется для разделения логики обработки
+ * @param {string | null} param - Параметр для проверки
+ * @returns {boolean} True если это реферальный код
+ */
+export function isStartParamReferralCode(param: string | null): boolean {
+  return isReferralCode(param)
+}

--- a/utils/attribution.ts
+++ b/utils/attribution.ts
@@ -82,16 +82,25 @@ function convertToAttribution(obj: Record<string, any>): AttributionData {
  */
 function getStartParam(): string | null {
   try {
+    console.log('[Attribution] Debug - Telegram.WebApp exists:', !!window.Telegram?.WebApp)
+    console.log('[Attribution] Debug - initDataUnsafe:', window.Telegram?.WebApp?.initDataUnsafe)
+    console.log('[Attribution] Debug - start_param:', window.Telegram?.WebApp?.initDataUnsafe?.start_param)
+    console.log('[Attribution] Debug - window.location.search:', window.location.search)
+    console.log('[Attribution] Debug - window.location.href:', window.location.href)
+
     // Метод 1: Получить из initDataUnsafe.start_param (Telegram WebApp)
     const webAppStartParam = window.Telegram?.WebApp?.initDataUnsafe?.start_param
     if (webAppStartParam) {
+      console.log('[Attribution] Debug - found in initDataUnsafe:', webAppStartParam)
       return webAppStartParam
     }
 
     // Метод 2: Получить из URL параметров (Direct Link)
     const urlParams = new URLSearchParams(window.location.search)
+    console.log('[Attribution] Debug - URL params:', Object.fromEntries(urlParams.entries()))
     const startParam = urlParams.get('start') || urlParams.get('startapp') || urlParams.get('tgWebAppStartParam')
     if (startParam) {
+      console.log('[Attribution] Debug - found in URL:', startParam)
       return startParam
     }
 

--- a/utils/attribution.ts
+++ b/utils/attribution.ts
@@ -82,25 +82,37 @@ function convertToAttribution(obj: Record<string, any>): AttributionData {
  */
 function getStartParam(): string | null {
   try {
-    console.log('[Attribution] Debug - Telegram.WebApp exists:', !!window.Telegram?.WebApp)
-    console.log('[Attribution] Debug - initDataUnsafe:', window.Telegram?.WebApp?.initDataUnsafe)
-    console.log('[Attribution] Debug - start_param:', window.Telegram?.WebApp?.initDataUnsafe?.start_param)
-    console.log('[Attribution] Debug - window.location.search:', window.location.search)
-    console.log('[Attribution] Debug - window.location.href:', window.location.href)
-
     // Метод 1: Получить из initDataUnsafe.start_param (Telegram WebApp)
     const webAppStartParam = window.Telegram?.WebApp?.initDataUnsafe?.start_param
     if (webAppStartParam) {
-      console.log('[Attribution] Debug - found in initDataUnsafe:', webAppStartParam)
       return webAppStartParam
     }
 
-    // Метод 2: Получить из URL параметров (Direct Link)
+    // Метод 2: Получить из hash-фрагмента (Telegram передаёт данные через #tgWebAppData=)
+    const hash = window.location.hash
+    if (hash && hash.startsWith('#tgWebAppData=')) {
+      try {
+        const hashParams = new URLSearchParams(hash.substring(1))
+        const tgWebAppData = hashParams.get('tgWebAppData')
+        if (tgWebAppData) {
+          // Декодируем tgWebAppData - это может содержать start_param
+          const decoded = decodeURIComponent(tgWebAppData)
+          const params = new URLSearchParams(decoded)
+          const startFromHash = params.get('start') || params.get('startapp')
+          if (startFromHash) {
+            console.log('[Attribution] Found in hash tgWebAppData:', startFromHash)
+            return startFromHash
+          }
+        }
+      } catch (e) {
+        console.warn('[Attribution] Error parsing hash:', e)
+      }
+    }
+
+    // Метод 3: Получить из URL параметров (Direct Link)
     const urlParams = new URLSearchParams(window.location.search)
-    console.log('[Attribution] Debug - URL params:', Object.fromEntries(urlParams.entries()))
     const startParam = urlParams.get('start') || urlParams.get('startapp') || urlParams.get('tgWebAppStartParam')
     if (startParam) {
-      console.log('[Attribution] Debug - found in URL:', startParam)
       return startParam
     }
 

--- a/utils/attribution.ts
+++ b/utils/attribution.ts
@@ -82,8 +82,11 @@ function convertToAttribution(obj: Record<string, any>): AttributionData {
  */
 function getStartParam(): string | null {
   try {
+    console.log('[Attribution] Debug - full hash:', window.location.hash)
+
     // Метод 1: Получить из initDataUnsafe.start_param (Telegram WebApp)
     const webAppStartParam = window.Telegram?.WebApp?.initDataUnsafe?.start_param
+    console.log('[Attribution] Debug - initDataUnsafe.start_param:', webAppStartParam)
     if (webAppStartParam) {
       return webAppStartParam
     }
@@ -92,17 +95,15 @@ function getStartParam(): string | null {
     const hash = window.location.hash
     if (hash && hash.startsWith('#tgWebAppData=')) {
       try {
-        const hashParams = new URLSearchParams(hash.substring(1))
-        const tgWebAppData = hashParams.get('tgWebAppData')
-        if (tgWebAppData) {
-          // Декодируем tgWebAppData - это может содержать start_param
-          const decoded = decodeURIComponent(tgWebAppData)
-          const params = new URLSearchParams(decoded)
-          const startFromHash = params.get('start') || params.get('startapp')
-          if (startFromHash) {
-            console.log('[Attribution] Found in hash tgWebAppData:', startFromHash)
-            return startFromHash
-          }
+        const hashContent = hash.substring('#tgWebAppData='.length)
+        console.log('[Attribution] Debug - hash content (truncated):', hashContent.substring(0, 200))
+        const decoded = decodeURIComponent(hashContent)
+        console.log('[Attribution] Debug - decoded (truncated):', decoded.substring(0, 200))
+        const params = new URLSearchParams(decoded)
+        const startFromHash = params.get('start') || params.get('startapp')
+        console.log('[Attribution] Debug - start from hash:', startFromHash)
+        if (startFromHash) {
+          return startFromHash
         }
       } catch (e) {
         console.warn('[Attribution] Error parsing hash:', e)
@@ -111,7 +112,9 @@ function getStartParam(): string | null {
 
     // Метод 3: Получить из URL параметров (Direct Link)
     const urlParams = new URLSearchParams(window.location.search)
+    console.log('[Attribution] Debug - URL search:', window.location.search)
     const startParam = urlParams.get('start') || urlParams.get('startapp') || urlParams.get('tgWebAppStartParam')
+    console.log('[Attribution] Debug - start from URL search:', startParam)
     if (startParam) {
       return startParam
     }

--- a/utils/attribution.ts
+++ b/utils/attribution.ts
@@ -79,44 +79,41 @@ function convertToAttribution(obj: Record<string, any>): AttributionData {
 /**
  * Получить start параметр из Telegram WebApp или URL
  * @returns {string | null} Значение start параметра или null
+ * 
+ * ВАЖНО: Для direct links (?startapp=) Telegram может не передавать start_param в initDataUnsafe.
  */
 function getStartParam(): string | null {
   try {
-    console.log('[Attribution] Debug - full hash:', window.location.hash)
-
     // Метод 1: Получить из initDataUnsafe.start_param (Telegram WebApp)
+    // Работает для attachment menu, может не работать для direct links
     const webAppStartParam = window.Telegram?.WebApp?.initDataUnsafe?.start_param
-    console.log('[Attribution] Debug - initDataUnsafe.start_param:', webAppStartParam)
     if (webAppStartParam) {
       return webAppStartParam
     }
 
-    // Метод 2: Получить из hash-фрагмента (Telegram передаёт данные через #tgWebAppData=)
+    // Метод 2: Проверить хэш напрямую - там могут быть параметры
+    // Формат: #tgWebAppData=...&tgWebAppVersion=...&...
     const hash = window.location.hash
-    if (hash && hash.startsWith('#tgWebAppData=')) {
-      try {
-        const hashContent = hash.substring('#tgWebAppData='.length)
-        console.log('[Attribution] Debug - hash content (truncated):', hashContent.substring(0, 200))
-        const decoded = decodeURIComponent(hashContent)
-        console.log('[Attribution] Debug - decoded (truncated):', decoded.substring(0, 200))
-        const params = new URLSearchParams(decoded)
-        const startFromHash = params.get('start') || params.get('startapp')
-        console.log('[Attribution] Debug - start from hash:', startFromHash)
-        if (startFromHash) {
-          return startFromHash
+    if (hash && hash.startsWith('#')) {
+      // Парсим хэш вручную - разбиваем по & и =
+      const hashContent = hash.substring(1) // убираем #
+      const pairs = hashContent.split('&')
+      for (const pair of pairs) {
+        const idx = pair.indexOf('=')
+        if (idx > 0) {
+          const key = pair.substring(0, idx)
+          if (key === 'start' || key === 'startapp' || key === 'tgWebAppStartParam') {
+            return decodeURIComponent(pair.substring(idx + 1))
+          }
         }
-      } catch (e) {
-        console.warn('[Attribution] Error parsing hash:', e)
       }
     }
 
-    // Метод 3: Получить из URL параметров (Direct Link)
+    // Метод 3: Попробовать через URLSearchParams
     const urlParams = new URLSearchParams(window.location.search)
-    console.log('[Attribution] Debug - URL search:', window.location.search)
-    const startParam = urlParams.get('start') || urlParams.get('startapp') || urlParams.get('tgWebAppStartParam')
-    console.log('[Attribution] Debug - start from URL search:', startParam)
-    if (startParam) {
-      return startParam
+    const startFromSearch = urlParams.get('start') || urlParams.get('startapp') || urlParams.get('tgWebAppStartParam')
+    if (startFromSearch) {
+      return startFromSearch
     }
 
     return null

--- a/utils/attribution.ts
+++ b/utils/attribution.ts
@@ -3,8 +3,6 @@
  * Извлекает UTM параметры из start параметра Telegram Mini App
  */
 
-import { isTelegramEnvironment } from './telegramUserUtils';
-
 export interface AttributionData {
   utm_source?: string;
   utm_medium?: string;
@@ -84,18 +82,13 @@ function convertToAttribution(obj: Record<string, any>): AttributionData {
  */
 function getStartParam(): string | null {
   try {
-    const isTg = isTelegramEnvironment()
-    if (!isTg) {
-      return null
-    }
-
-    // Метод 1: Получить из initDataUnsafe.start_param
+    // Метод 1: Получить из initDataUnsafe.start_param (Telegram WebApp)
     const webAppStartParam = window.Telegram?.WebApp?.initDataUnsafe?.start_param
     if (webAppStartParam) {
       return webAppStartParam
     }
 
-    // Метод 2: Получить из URL параметров
+    // Метод 2: Получить из URL параметров (Direct Link)
     const urlParams = new URLSearchParams(window.location.search)
     const startParam = urlParams.get('start') || urlParams.get('startapp') || urlParams.get('tgWebAppStartParam')
     if (startParam) {

--- a/utils/referralUtils.ts
+++ b/utils/referralUtils.ts
@@ -6,6 +6,7 @@ import { bumpReferralDataSyncVersion } from '@/src/stores/sync-triggers.store';
 
 import { getTelegramUserId, isTelegramEnvironment } from './telegramUserUtils';
 import { loadUserStats, saveUserStats } from '../services/userStatsService';
+import { isStartParamReferralCode } from './attribution';
 
 // Ключи для localStorage
 const REFERRAL_CODE_KEY = 'menhausen_referral_code';
@@ -30,14 +31,24 @@ export function getReferralCodeFromStartParam(): string | null {
     // Метод 1: Получить из initDataUnsafe.start_param
     const webAppStartParam = window.Telegram?.WebApp?.initDataUnsafe?.start_param;
     if (webAppStartParam) {
-      return webAppStartParam;
+      // Проверяем: это реферальный код (REF_*), а не UTM атрибуция
+      if (isStartParamReferralCode(webAppStartParam)) {
+        return webAppStartParam;
+      }
+      // Это UTM атрибуция - не реферальный код
+      return null;
     }
 
     // Метод 2: Получить из URL параметров
     const urlParams = new URLSearchParams(window.location.search);
-    const startParam = urlParams.get('startapp') || urlParams.get('tgWebAppStartParam');
+    const startParam = urlParams.get('start') || urlParams.get('startapp') || urlParams.get('tgWebAppStartParam');
     if (startParam) {
-      return startParam;
+      // Проверяем: это реферальный код (REF_*), а не UTM атрибуция
+      if (isStartParamReferralCode(startParam)) {
+        return startParam;
+      }
+      // Это UTM атрибуция - не реферальный код
+      return null;
     }
 
     return null;


### PR DESCRIPTION
# UTM Attribution Implementation Plan

## Goal

Track user acquisition source in PostHog by extracting UTM parameters from Telegram Mini App start parameter.

## Context

When users open the Mini App via link like `https://t.me/menhausen_app_bot/app?start=eyJzIjoiZmFjZWJvb2siLCJ0IjoxNzc2MjcwOTkwLCJ2IjoxfQ`:

1. Extract `start` parameter from URL (`tgWebAppStartParam`)
2. Decode base64url → JSON: `{s, m, c, r, t, v}`
3. Map to UTM fields: `s`→utm_source, `m`→utm_medium, `c`→utm_campaign, `r`→utm_referrer
4. Initialize PostHog with user ID as distinct_id
5. On `identify()`: pass utm_* as person properties
6. On every `track()`: include utm_* in properties

## Edge Case: Referral codes

Existing referral system uses `?startapp=REF_123456`. Need to differentiate:

- `start.startsWith('REF_')` → referral code (existing logic)
- base64-decodable JSON with `t, v` → UTM attribution (new logic)

---

## Implementation Steps

### Step 1: Create `utils/attribution.ts`

```typescript
interface AttributionData {
  utm_source?: string;
  utm_medium?: string;
  utm_campaign?: string;
  utm_referrer?: string;
  attribution_timestamp: number;
  attribution_version: number;
}

// Decode base64url to JSON
function decodeBase64Url(encoded: string): string {
  const base64 = encoded.replace(/-/g, '+').replace(/_/g, '/')
  return atob(base64)
}

// Parse attribution from start param
export function getAttributionFromStartParam(): AttributionData | null {
  // 1. Get start_param from Telegram or URL
  // 2. Check if it's NOT a referral code (doesn't start with REF_)
  // 3. Try to decode as base64 → JSON
  // 4. Validate presence of 't' and 'v' fields
  // 5. Map s→utm_source, m→utm_medium, c→utm_campaign, r→utm_referrer
  // 6. Console.log debug info
}
```

### Step 2: Update `utils/referralUtils.ts`

Modify `getReferralCodeFromStartParam()`:
- If param starts with `REF_` → return referral code (existing)
- If param is valid UTM JSON → return `null` (UTM handled separately)
- If neither → return `null`

Add `processAttribution()` wrapper that calls `getAttributionFromStartParam()` and returns data.

### Step 3: Update `utils/analytics/posthog.ts`

```typescript
// Module-level variable to store attribution
let storedAttribution: AttributionData | null = null

export function setAttributionData(data: AttributionData): void {
  storedAttribution = data
}

export function capture(eventName: string, properties?: Record<string, any>): void {
  // ... existing logic
  const utmProps = storedAttribution ? {
    utm_source: storedAttribution.utm_source,
    utm_medium: storedAttribution.utm_medium,
    utm_campaign: storedAttribution.utm_campaign,
    utm_referrer: storedAttribution.utm_referrer,
  } : {}
  
  posthog.capture(eventName, {
    ...defaultEventProps,
    ...uidProps,
    ...experimentProps,
    ...utmProps,  // ← Add UTM to all events
    ...(properties || {}),
  })
}

export function identify(distinctId: string, properties?: Record<string, any>): void {
  // ... existing logic
  const utmProps = storedAttribution ? {
    utm_source: storedAttribution.utm_source,
    utm_medium: storedAttribution.utm_medium,
    utm_campaign: storedAttribution.utm_campaign,
    utm_referrer: storedAttribution.utm_referrer,
  } : {}
  
  posthog.identify(distinctId, {
    ...defaultProps,
    ...utmProps,  // ← Add UTM to person properties
    ...(properties || {}),
  })
}
```

### Step 4: Integrate in `AppContent.tsx`

```typescript
// At app initialization (before processReferralCode):
const startParam = getStartParamFromUrl()
const attribution = getAttributionFromStartParam()

// Debug console output
console.log('[Attribution] Full start param:', startParam)
console.log('[Attribution] Decoded attribution:', attribution)
console.log('[Attribution] Referral code:', referralCode)

if (attribution) {
  setAttributionData(attribution)
}

// Existing referral processing
processReferralCode()

// Identify with UTM (utm_* added automatically)
if (userId) {
  identify(userId)
}
```

---

## Files to Modify

| File | Action |
|------|--------|
| `utils/attribution.ts` | **Create** |
| `utils/referralUtils.ts` | Update type detection logic |
| `utils/analytics/posthog.ts` | Add UTM to capture/identify |
| `AppContent.tsx` | Initialize attribution at startup |

---

## PostHog Data Flow

1. **Person properties** (on identify):
   - `utm_source`
   - `utm_medium`
   - `utm_campaign`
   - `utm_referrer`

2. **Event properties** (on every capture):
   - `utm_source`
   - `utm_medium`
   - `utm_campaign`
   - `utm_referrer`

---

## Console Debug Output

```
[Attribution] Start param: eyJzIjoiZmFjZWJvb2siLCJ0IjoxNzc2MjcwOTkwLCJ2IjoxfQ
[Attribution] Decoded: { s: "facebook", m: "cpc", c: "summer", r: "facebook.com", t: 1776270990, v: 1 }
[Attribution] Attribution data: { utm_source: "facebook", utm_medium: "cpc", utm_campaign: "summer", utm_referrer: "facebook.com", ... }
[Attribution] Referral code: null (detected as UTM, not REF_*)
```

---

## Testing Checklist

- [ ] Open app with `?start=eyJzIjoiZmFjZWJvb2si...` — attribution extracted
- [ ] Open app with `?startapp=REF_123456` — referral works (existing)
- [ ] Open app without start param — no errors
- [ ] PostHog identify includes utm_* as person properties
- [ ] PostHog capture includes utm_* in event properties