### PR TITLE
JWT auth single-flight fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "menhausen-telegram-mini-app",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "menhausen-telegram-mini-app",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "dependencies": {
         "@floating-ui/react": "^0.26.0",
         "@nanostores/i18n": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "menhausen-telegram-mini-app",
   "private": true,
-  "version": "1.4.1",
+  "version": "1.4.2",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/tests/unit/supabaseSync/authService.test.ts
+++ b/tests/unit/supabaseSync/authService.test.ts
@@ -1,15 +1,26 @@
 /**
  * Authentication Service Unit Tests
- * 
- * Tests for JWT token management and Telegram authentication flow
- * 
- * Note: This is a basic test structure. Full testing requires:
- * - Real Supabase project for integration tests
- * - Valid Telegram initData for E2E tests
- * - Mock Supabase Edge Functions for unit tests
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { withMockedFetch } from '../helpers/fetchMock';
+
+vi.mock('@/utils/analytics/posthog', () => ({
+  captureException: vi.fn(),
+}));
+
+vi.mock('@/src/stores/auth.store', () => ({
+  setAuthState: vi.fn(),
+}));
+
+function createTestJwt(expiresAtMs: number): string {
+  const exp = Math.floor(expiresAtMs / 1000);
+  const payload = btoa(JSON.stringify({ exp }))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+  return `hdr.${payload}.sig`;
+}
 
 describe('authService - Token Storage Utilities', () => {
   beforeEach(() => {
@@ -17,40 +28,132 @@ describe('authService - Token Storage Utilities', () => {
   });
 
   it('should handle JWT token expiry correctly', () => {
-    const futureTime = Date.now() + 3600000; // 1 hour from now
-    const pastTime = Date.now() - 1000; // 1 second ago
-    
+    const futureTime = Date.now() + 3600000;
+    const pastTime = Date.now() - 1000;
+
     expect(futureTime > Date.now()).toBe(true);
     expect(pastTime < Date.now()).toBe(true);
   });
 
   it('should validate token expiry logic', () => {
     const now = Date.now();
-    const validExpiry = now + 3600000; // 1 hour from now
-    const expiredTime = now - 1000; // 1 second ago
-    
-    // Token is valid if expiry > current time
+    const validExpiry = now + 3600000;
+    const expiredTime = now - 1000;
+
     expect(validExpiry > now).toBe(true);
     expect(expiredTime > now).toBe(false);
   });
+});
 
-  it('should handle missing token expiry gracefully', () => {
-    const expiry: string | null = null;
-    const isValid = expiry !== null && parseInt(expiry, 10) > Date.now();
-    expect(isValid).toBe(false);
+describe('authService.getValidJWTToken', () => {
+  let fetchMockControl: ReturnType<typeof withMockedFetch>;
+
+  const localStorageMock = {
+    storage: {} as Record<string, string>,
+    getItem: vi.fn((key: string) => localStorageMock.storage[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      localStorageMock.storage[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete localStorageMock.storage[key];
+    }),
+    clear: vi.fn(() => {
+      localStorageMock.storage = {};
+    }),
+  };
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    vi.stubEnv('VITE_SUPABASE_URL', 'https://test.supabase.co');
+    vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'anon-key');
+
+    localStorageMock.storage = {};
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: localStorageMock,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(window, 'localStorage', {
+      value: localStorageMock,
+      writable: true,
+      configurable: true,
+    });
+
+    (window as any).Telegram = {
+      WebApp: {
+        initData: 'user=%7B%22id%22%3A123%7D&auth_date=1&hash=abc',
+      },
+    };
+
+    fetchMockControl = withMockedFetch();
   });
 
-  it('should correctly calculate token expiry buffer', () => {
-    // Token should be refreshed if it expires in less than 5 minutes (300000 ms)
-    const refreshBuffer = 300000; // 5 minutes
-    const tokenExpiry = Date.now() + 600000; // 10 minutes from now
-    const shouldRefresh = tokenExpiry - Date.now() < refreshBuffer;
-    
-    expect(shouldRefresh).toBe(false); // Should not refresh yet
-    
-    const soonToExpire = Date.now() + 60000; // 1 minute from now
-    const shouldRefreshSoon = soonToExpire - Date.now() < refreshBuffer;
-    
-    expect(shouldRefreshSoon).toBe(true); // Should refresh soon
+  afterEach(() => {
+    fetchMockControl.restore();
+    vi.unstubAllEnvs();
+  });
+
+  it('returns stored token without calling auth when not expired', async () => {
+    const token = createTestJwt(Date.now() + 3_600_000);
+    localStorageMock.storage.supabase_jwt_token = token;
+    localStorageMock.storage.supabase_jwt_token_expiry = String(Date.now() + 3_600_000);
+
+    const { getValidJWTToken } = await import('@/utils/supabaseSync/authService');
+    const result = await getValidJWTToken();
+
+    expect(result).toBe(token);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('deduplicates concurrent refresh calls into a single auth request', async () => {
+    const token = createTestJwt(Date.now() + 3_600_000);
+    let resolveAuth: (value: unknown) => void = () => {};
+    const authDeferred = new Promise((resolve) => {
+      resolveAuth = resolve;
+    });
+
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockImplementation(() => authDeferred);
+
+    const { getValidJWTToken } = await import('@/utils/supabaseSync/authService');
+    const pending = Promise.all([
+      getValidJWTToken(),
+      getValidJWTToken(),
+      getValidJWTToken(),
+    ]);
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+
+    resolveAuth({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: new Headers(),
+      json: async () => ({ success: true, token }),
+    });
+
+    const results = await pending;
+    expect(results).toEqual([token, token, token]);
+  });
+
+  it('records last auth error when refresh fails', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+      headers: new Headers(),
+      text: async () => JSON.stringify({ error: 'Invalid signature', code: 'AUTH_FAILED' }),
+      json: async () => ({ error: 'Invalid signature', code: 'AUTH_FAILED' }),
+    });
+
+    const { getValidJWTToken, getLastAuthError } = await import('@/utils/supabaseSync/authService');
+    const result = await getValidJWTToken();
+
+    expect(result).toBeNull();
+    expect(getLastAuthError()).toEqual({
+      error: 'Invalid signature',
+      code: 'AUTH_FAILED',
+    });
   });
 });

--- a/tests/unit/telegramStarsPaymentService.test.ts
+++ b/tests/unit/telegramStarsPaymentService.test.ts
@@ -15,6 +15,7 @@ vi.mock('../../utils/telegramUserUtils', () => ({
 
 vi.mock('../../utils/supabaseSync/authService', () => ({
   getValidJWTToken: vi.fn(),
+  getLastAuthError: vi.fn(),
 }));
 
 // Mock localStorage
@@ -80,6 +81,7 @@ beforeEach(() => {
   // Default mocks
   vi.mocked(telegramUserUtils.getTelegramUserId).mockReturnValue('123456789');
   vi.mocked(authService.getValidJWTToken).mockResolvedValue('test-jwt-token');
+  vi.mocked(authService.getLastAuthError).mockReturnValue(null);
 });
 
 afterEach(() => {

--- a/utils/supabaseSync/authService.ts
+++ b/utils/supabaseSync/authService.ts
@@ -10,6 +10,14 @@ import { setAuthState } from '../../src/stores/auth.store';
 const JWT_TOKEN_KEY = 'supabase_jwt_token';
 const JWT_TOKEN_EXPIRY_KEY = 'supabase_jwt_token_expiry';
 
+export interface AuthError {
+  error?: string;
+  code?: string;
+}
+
+let refreshPromise: Promise<string | null> | null = null;
+let lastAuthError: AuthError | null = null;
+
 interface AuthResponse {
   success: boolean;
   token?: string;
@@ -347,32 +355,53 @@ export async function deleteUserDataFromSupabase(): Promise<{ success: boolean; 
 }
 
 /**
- * Get JWT token, refreshing if expired
+ * Last auth failure from getValidJWTToken refresh flow (for diagnostics / user messaging).
+ */
+export function getLastAuthError(): AuthError | null {
+  return lastAuthError;
+}
+
+async function performTokenRefresh(): Promise<string | null> {
+  console.log('[authService] Refreshing JWT token...');
+  const authResult = await refreshJWTToken();
+  if (authResult.success && authResult.token) {
+    lastAuthError = null;
+    console.log('[authService] JWT token refreshed successfully');
+    return authResult.token;
+  }
+
+  lastAuthError = { error: authResult.error, code: authResult.code };
+  console.error('[authService] Failed to refresh JWT token:', authResult.error);
+  return null;
+}
+
+/**
+ * Get JWT token, refreshing if expired.
+ * Concurrent callers share a single in-flight refresh to avoid auth races.
  */
 export async function getValidJWTToken(): Promise<string | null> {
-  let token = getJWTToken();
+  const token = getJWTToken();
   const isExpired = isJWTTokenExpired();
-  
+
   console.log('[authService] getValidJWTToken - has token:', !!token, 'is expired:', isExpired);
-  
-  if (!token || isExpired) {
-    // Token missing or expired, refresh it
-    console.log('[authService] Refreshing JWT token...');
-    const authResult = await refreshJWTToken();
-    if (authResult.success && authResult.token) {
-      token = authResult.token;
-      console.log('[authService] JWT token refreshed successfully');
-    } else {
-      console.error('[authService] Failed to refresh JWT token:', authResult.error);
-      return null;
-    }
-  } else {
+
+  if (token && !isExpired) {
     console.log('[authService] Using existing JWT token');
+    setAuthState({ jwtExpiresAt: getTokenExpiry(token) ?? null });
+    return token;
   }
 
-  if (token) {
-    setAuthState({ jwtExpiresAt: getTokenExpiry(token) ?? null })
+  if (!refreshPromise) {
+    refreshPromise = performTokenRefresh().finally(() => {
+      refreshPromise = null;
+    });
   }
 
-  return token;
+  const refreshedToken = await refreshPromise;
+
+  if (refreshedToken) {
+    setAuthState({ jwtExpiresAt: getTokenExpiry(refreshedToken) ?? null });
+  }
+
+  return refreshedToken;
 }

--- a/utils/telegramStarsPaymentService.ts
+++ b/utils/telegramStarsPaymentService.ts
@@ -5,7 +5,7 @@
  */
 
 import { getTelegramUserId } from './telegramUserUtils';
-import { getValidJWTToken } from './supabaseSync/authService';
+import { getLastAuthError, getValidJWTToken } from './supabaseSync/authService';
 import { AnalyticsEvent, capture, captureException } from './analytics/posthog';
 import { $screenParams } from '@/src/stores/screen-params.store';
 import { $experimentVariant } from '@/src/stores/experiment.store';
@@ -65,7 +65,12 @@ class TelegramStarsPaymentService {
     // Get JWT token for authentication
     const jwtToken = await getValidJWTToken();
     if (!jwtToken) {
-      throw new Error('JWT token not available. Please authenticate first.');
+      const authError = getLastAuthError();
+      throw new Error(
+        authError?.error
+          ? `Authentication failed: ${authError.error}`
+          : 'JWT token not available. Please authenticate first.'
+      );
     }
     
     // Prepare headers


### PR DESCRIPTION
# JWT auth single-flight fix

## Root cause
The PostHog error `JWT token not available. Please authenticate first.` ([telegramStarsPaymentService.ts:68](utils/telegramStarsPaymentService.ts)) is a symptom. It's thrown whenever `getValidJWTToken()` returns `null`, which happens when `authenticateWithTelegram()` fails against the `auth-telegram` edge function.

The sibling PostHog issues show the real failures:
- `Failed to create session for existing user: Invalid login credentials`
- `Database error creating new user`

`auth-telegram` rotates the user's password and `signInWithPassword`s on every auth (and creates the user on first auth). Multiple independent callers of `getValidJWTToken()` fire concurrently on a fresh session (`supabaseSyncService.initializeSupabase`, `premium.store` reconciliation via `fetchUserData`, `rewardService.grantReward`, `createInvoice`). `getValidJWTToken()` in [authService.ts](utils/supabaseSync/authService.ts) has no in-flight de-duplication, so each does a full re-auth. Concurrent re-auths clobber each other's passwords (`Invalid login credentials`) and race on user creation (`Database error`) -> `null` token -> generic payment error.

## Fix (client-only)

### 1. Single-flight de-duplication in `getValidJWTToken` ([authService.ts](utils/supabaseSync/authService.ts))
- Add a module-level `let refreshPromise: Promise<string | null> | null = null`.
- Fast path: if a stored token exists and is not expired, return it immediately (update `setAuthState`).
- Slow path: if a refresh is needed, only the first caller creates the refresh promise; concurrent callers `await` the same `refreshPromise`. Clear it in `.finally()` so the next genuine expiry can refresh again.
- This guarantees at most one `authenticateWithTelegram()` network call in flight, removing the concurrency that causes the password-rotation race and duplicate user creation.

### 2. Surface the real auth error
- Add a module-level `lastAuthError: { error?: string; code?: string } | null`, set from the failed `authResult` inside the refresh flow, and export `getLastAuthError()`.
- In [telegramStarsPaymentService.ts](utils/telegramStarsPaymentService.ts) `createInvoice`, when the token is `null`, throw a message that includes the real reason when available, falling back to the original text:
  - `Authentication failed: <reason>` when `getLastAuthError()?.error` is set,
  - otherwise the existing `JWT token not available. Please authenticate first.`
- This keeps future PostHog reports diagnosable and shows users an accurate message, while preserving the fallback string so existing tests that mock `getValidJWTToken -> null` still pass.

## Tests
- Add `tests/unit/supabaseSync/authService.test.ts` verifying that N concurrent `getValidJWTToken()` calls (no stored token) trigger exactly one `authenticateWithTelegram` / one `fetch`, and all resolve to the same token.
- Confirm existing [telegramStarsPaymentService.test.ts](tests/unit/telegramStarsPaymentService.test.ts) still passes (the JWT-null case falls back to the original message).
- Run `npm run type-check` and `npm run test:run`.

## Out of scope (recommended follow-up)
Server-side: stop rotating the auth user's password on every `auth-telegram` call (deterministic password or non-password session). Not included per chosen client-only scope.