### PR TITLE
fix(sync): harden batch upload against mobile network failures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "menhausen-telegram-mini-app",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "menhausen-telegram-mini-app",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "dependencies": {
         "@floating-ui/react": "^0.26.0",
         "@nanostores/i18n": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "menhausen-telegram-mini-app",
   "private": true,
-  "version": "1.4.3",
+  "version": "1.4.4",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/tests/unit/supabaseSync/networkRetry.test.ts
+++ b/tests/unit/supabaseSync/networkRetry.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@/utils/supabaseSync/authService', () => ({
+  getValidJWTToken: vi.fn().mockResolvedValue('fake.jwt.token'),
+}));
+
+describe('SupabaseSyncService network retry', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    localStorage.clear();
+    vi.stubEnv('VITE_SUPABASE_URL', 'https://example.supabase.co');
+    vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'test-anon-key');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('retries transient Failed to fetch errors before succeeding', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => ({ success: true, syncedTypes: ['preferences'] }),
+      });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { getSyncService } = await import('@/utils/supabaseSync/supabaseSyncService');
+    const svc = getSyncService();
+    await (svc as unknown as { initializationPromise: Promise<void> }).initializationPromise;
+
+    const internal = svc as unknown as {
+      supabase: unknown;
+      config: { maxRetries: number; retryDelayMs: number };
+      syncToSupabase: (data: Record<string, unknown>) => Promise<{ success: boolean }>;
+    };
+    internal.supabase = {};
+    internal.config.maxRetries = 3;
+    internal.config.retryDelayMs = 1;
+
+    const result = await internal.syncToSupabase({ preferences: { theme: 'dark' } });
+
+    expect(result.success).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({
+      mode: 'cors',
+      credentials: 'omit',
+      method: 'POST',
+    });
+  });
+});

--- a/utils/supabaseSync/supabaseSyncService.ts
+++ b/utils/supabaseSync/supabaseSyncService.ts
@@ -44,6 +44,9 @@ export class SupabaseSyncService {
   private supabase: SupabaseClient | null = null;
   /** Serializes initialSync/forceSync so concurrent callers wait instead of failing. */
   private syncMutex: Promise<void> = Promise.resolve();
+  /** Serializes upload POSTs so batch sync and background initial sync do not race on mobile. */
+  private uploadMutex: Promise<void> = Promise.resolve();
+  private offlineRetryTimer: number | null = null;
   private offlineQueue: SyncQueueItem[] = [];
   private fetchCache: {
     inFlight: Promise<UserDataFromAPI | null> | null;
@@ -328,6 +331,7 @@ export class SupabaseSyncService {
 
       if (this.config.enableOfflineQueue) {
         this.enqueueOfflineBatch(Array.from(types), data);
+        this.scheduleOfflineQueueRetry();
       }
 
       for (const type of types) {
@@ -501,6 +505,50 @@ export class SupabaseSyncService {
     this.saveOfflineQueue();
   }
 
+  private static isFetchNetworkError(error: unknown): boolean {
+    return error instanceof TypeError && error.message === 'Failed to fetch';
+  }
+
+  private scheduleOfflineQueueRetry(): void {
+    if (!this.config.enableOfflineQueue || this.offlineQueue.length === 0) {
+      return;
+    }
+    if (this.offlineRetryTimer != null) {
+      return;
+    }
+    this.offlineRetryTimer = window.setTimeout(() => {
+      this.offlineRetryTimer = null;
+      void this.processOfflineQueue();
+    }, this.config.retryDelayMs);
+  }
+
+  private async fetchSupabaseFunction(url: string, init: RequestInit): Promise<Response> {
+    const maxAttempts = Math.max(1, this.config.maxRetries);
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        return await fetch(url, {
+          mode: 'cors',
+          credentials: 'omit',
+          ...init,
+        });
+      } catch (error) {
+        lastError = error;
+        const canRetry =
+          SupabaseSyncService.isFetchNetworkError(error) && attempt < maxAttempts;
+        if (!canRetry) {
+          throw error;
+        }
+        const delayMs = this.config.retryDelayMs * attempt;
+        syncLog.debug(
+          `[SyncService] fetch network error, retry ${attempt}/${maxAttempts} in ${delayMs}ms`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      }
+    }
+    throw lastError;
+  }
+
   /**
    * Fetch user data from Supabase
    */
@@ -645,7 +693,22 @@ export class SupabaseSyncService {
         errors: [],
       };
     }
-    
+
+    const previous = this.uploadMutex;
+    let release!: () => void;
+    this.uploadMutex = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+
+    try {
+      return await this.runSyncToSupabaseImpl(data);
+    } finally {
+      release();
+    }
+  }
+
+  private async runSyncToSupabaseImpl(data: any): Promise<SyncResult> {
     if (!this.supabase) {
       throw new Error('Supabase client not initialized');
     }
@@ -701,8 +764,7 @@ export class SupabaseSyncService {
         throw new Error('No authentication method available (JWT token or Telegram initData)');
       }
 
-      // Call Edge Function
-      const response = await fetch(url, {
+      const response = await this.fetchSupabaseFunction(url, {
         method: 'POST',
         headers,
         body,
@@ -1074,6 +1136,7 @@ export class SupabaseSyncService {
               console.warn('[SyncService] Background upload failed:', error);
               const err = error instanceof Error ? error : new Error(String(error));
               this.enqueueOfflineBatch(Array.from(dirtyTypes), localData);
+              this.scheduleOfflineQueueRetry();
               reportIncrementalSyncError(err.message);
             });
         }
@@ -1115,6 +1178,7 @@ export class SupabaseSyncService {
               console.warn('[SyncService] Background upload failed:', error);
               const err = error instanceof Error ? error : new Error(String(error));
               this.enqueueOfflineBatch(uploadedTypes, localData);
+              this.scheduleOfflineQueueRetry();
               reportIncrementalSyncError(err.message);
             });
           this.syncStatus.lastSync = new Date();


### PR DESCRIPTION
## Summary

- Fixes PostHog error `TypeError: Failed to fetch` in `syncToSupabase` / `flushPendingBatchSync` (Android, 1 user after deploy).
- Serialize upload POSTs with an upload mutex so batch sync and background initial sync do not race.
- Retry transient `Failed to fetch` errors with exponential backoff (uses existing `maxRetries` / `retryDelayMs` config).
- Add explicit `mode: 'cors'` and `credentials: 'omit'` to sync POST fetch (parity with `fetchFromSupabase` and `authService`).
- Schedule offline queue retry after failures without requiring an offline→online cycle.

## Root cause

The error is a client-side network failure before any HTTP response (not a server 4xx/5xx). Supabase edge logs show multiple concurrent `sync-user-data` POSTs in the same session; on mobile this increases the chance of a dropped connection. The security migration does not affect the sync path (Edge Functions use `service_role`).

## Test plan

- [x] `tests/unit/supabaseSync/networkRetry.test.ts` — retries after `Failed to fetch`
- [x] `tests/unit/supabaseSync/batchedSync.test.ts` — still passes
- [ ] Manual: open app on mobile, trigger preference/check-in changes, confirm sync succeeds
- [ ] Confirm PostHog issue does not recur for the same fingerprint


Made with [Cursor](https://cursor.com)